### PR TITLE
[standards] Добавить единый глоссарий терминов

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-26T11:25:16.776Z for PR creation at branch issue-21-c3cfbd77959b for issue https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/21
+# Updated: 2026-05-26T11:43:57.796Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-26T11:25:16.776Z for PR creation at branch issue-21-c3cfbd77959b for issue https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/21
-# Updated: 2026-05-26T11:43:57.796Z

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable repository governance changes are documented here.
 
 ### Added
 
+- Canonical glossary в `standards/GLOSSARY.md` для единых терминов standards,
+  governance и AI-assisted work.
 - Issue #17 migration structure: `CONCEPT.md`, обновленные root governance
   files, `standards/README.md`, `governance/REPO_MODEL.md` и `tools/`.
 - Repository structure validation в `tools/validate-repository-structure.sh`.
@@ -33,6 +35,7 @@ All notable repository governance changes are documented here.
 - [AI_GOVERNANCE.md](AI_GOVERNANCE.md)
 - [CONTRIBUTING.md](CONTRIBUTING.md)
 - [standards/README.md](standards/README.md)
+- [standards/GLOSSARY.md](standards/GLOSSARY.md)
 - [governance/REPO_MODEL.md](governance/REPO_MODEL.md)
 
 ## TODO

--- a/CONCEPT.md
+++ b/CONCEPT.md
@@ -89,7 +89,7 @@ traceable.
 | [standards/README.md](standards/README.md) | Реестр standards и инструкция применения. |
 | [governance/REPO_MODEL.md](governance/REPO_MODEL.md) | Правила структуры и Anti-Inflation. |
 | `TEAM_CONTRACT.md` | Шаблон командного соглашения для spoke-проектов; не является активным контрактом этого репозитория, пока файл не создан и не принят review. |
-| `GLOSSARY.md` | Планируемый источник единой терминологии; до его создания термины фиксируются в ближайшем active artifact или issue. |
+| [standards/GLOSSARY.md](standards/GLOSSARY.md) | Canonical источник единой терминологии для standards, governance и AI-assisted work. |
 
 ## Стандарты
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 | [CHANGELOG.md](CHANGELOG.md) | Date-based журнал governance-изменений репозитория. |
 | [LICENSE](LICENSE) | Текущий статус лицензии и pending-решение Founder & PO. |
 | [standards/README.md](standards/README.md) | Таблица активных и планируемых стандартов. |
+| [standards/GLOSSARY.md](standards/GLOSSARY.md) | Единый словарь терминов для standards, governance и AI-assisted work. |
 | [governance/REPO_MODEL.md](governance/REPO_MODEL.md) | Модель структуры репозитория и Anti-Inflation правило. |
 
 ## Структура

--- a/standards/GLOSSARY.md
+++ b/standards/GLOSSARY.md
@@ -1,0 +1,70 @@
+---
+status: canonical
+version: 1.0
+updated: 2026-05-26
+ai-generated: false
+---
+
+# Glossary
+
+Версия: 1.0
+
+Дата: 2026-05-26
+
+Этот глоссарий фиксирует рабочие определения терминов для
+`hybrid-Intelligence-lab`. Он нужен, чтобы issues, standards, governance-файлы
+и AI-assisted changes использовали одни и те же различия между типами правил,
+артефактов и режимов работы.
+
+## Как использовать
+
+1. При написании документа сверяйся с этим глоссарием до добавления нового
+   термина или смены значения существующего.
+2. Если термина нет, предложи добавление через Issue и укажи, какую
+   операционную путаницу он снижает.
+3. Используй `Policy`, `Standard`, `Contract` и `Guideline` как разные уровни
+   обязательности, а не как взаимозаменяемые слова.
+4. Для AI-assisted work явно указывай `Operating Mode`, если задача требует
+   поведения, отличного от обычной structured work.
+5. Ссылайся на canonical artifacts; `-old` files можно использовать как
+   historical input, но не как активный источник правил.
+
+## Термины
+
+| Термин | Краткое определение | Контекст использования | Пример артефакта |
+| --- | --- | --- | --- |
+| Standard | Переиспользуемое правило или шаблон, который задает обязательный формат, минимальные поля или review-критерии для группы артефактов. Standard создается только при повторяющейся coordination или review problem. | Отличается от `Guideline` обязательностью, от `Policy` - фокусом на формате и качестве артефакта, а не на разрешениях или запретах поведения. | [standards/README.md](README.md), [standards/GLOSSARY.md](GLOSSARY.md) |
+| Concept | Базовое описание цели, границ, аудитории и операционной модели решения. Concept объясняет, почему репозиторий или область устроены именно так. | Используется как смысловой источник для standards и policies. Отличается от `Framework`: concept фиксирует назначение и границы, framework задает метод работы. | [CONCEPT.md](../CONCEPT.md) |
+| Policy | Обязательное правило принятия решений или ограничения поведения: что разрешено, запрещено, требует review или эскалации. | Используется там, где нарушение создает риск для безопасности, публикации, governance или качества. Отличается от `Standard`: policy регулирует действия участников, standard регулирует форму и готовность артефактов. | [AI_GOVERNANCE.md](../AI_GOVERNANCE.md), [governance/REPO_MODEL.md](../governance/REPO_MODEL.md) |
+| Contract | Операционное соглашение между ролями, системами или репозиториями: обязанности, входы, выходы, lifecycle и критерии готовности. | Используется, когда важно зафиксировать взаимные ожидания, а не только отдельное правило. Contract может включать policies, standards и escalation rules. | [AI_GOVERNANCE.md](../AI_GOVERNANCE.md), future `TEAM_CONTRACT.md` |
+| Practice | Повторяемый способ работы, который помогает достигать качества или скорости, но может адаптироваться к контексту. | Используется для описания привычек команды: локальная проверка, source-backed analysis, review checklist. Practice может стать guideline или standard, если повторяется и дает устойчивую пользу. | [CONTRIBUTING.md](../CONTRIBUTING.md), [tools/validate-repository-structure.sh](../tools/validate-repository-structure.sh) |
+| Framework | Структурированная методология для класса задач: понятия, роли, workflow, decision points, ограничения и примеры применения. | Создается только после сравнения с существующими подходами и выявленного gap. Отличается от `Practice`: framework связывает несколько practices и concepts в целостную модель. | `frameworks/<slug>/README.md` по правилу [governance/REPO_MODEL.md](../governance/REPO_MODEL.md) |
+| Guideline | Рекомендация с объяснением, как действовать в типовом случае, без статуса жесткого правила. | Используется, когда полезен общий ориентир, но допустимы локальные исключения с объяснением в issue или PR. Отличается от `Policy`: guideline можно обоснованно обойти. | [CONTRIBUTING.md](../CONTRIBUTING.md), [standards/README.md](README.md) |
+| Artifact | Проверяемый объект репозитория, который хранит знание, решение, шаблон, правило, эксперимент или вспомогательную проверку. | Используется как единица review и traceability. Artifact не обязан быть документом: validation script тоже artifact, если он поддерживает governance. | [CONCEPT.md](../CONCEPT.md), [tools/validate-repository-structure.sh](../tools/validate-repository-structure.sh) |
+| Canonical | Текущий утвержденный источник истины для темы. Canonical artifact используется по умолчанию в issues, reviews и AI context. | Отличается от `Draft`: canonical можно применять как действующее правило или reference. Если canonical artifact изменяется, нужна reviewable причина и обновление навигации. | [CONCEPT.md](../CONCEPT.md) с `status: canonical` |
+| Draft | Черновик или proposal, который еще не является источником истины и требует review, проверки или решения owner. | Используется для исследовательских вариантов, будущих шаблонов и PR work-in-progress. Draft не должен отменять canonical artifact без явного решения в PR. | `research/<domain>/<topic>.md` до review, draft PR |
+| Operating Mode | Явно заданный режим работы AI-assisted task, который определяет ожидаемую автономию, тип результата и допустимый уровень исследования. | `structured` используется по умолчанию для конкретных инструкций; `creative` подходит, когда дана цель и нужны варианты; `research`, `education` и `project` уточняют тип работы. | [AI_GOVERNANCE.md](../AI_GOVERNANCE.md), [.github/ISSUE_TEMPLATE/task.yml](../.github/ISSUE_TEMPLATE/task.yml) |
+| Profile | Контекстная настройка framework, standard или risk model под конкретную область, проект, аудиторию или класс риска. | Используется, когда общий framework сохраняется, но нужны domain-specific controls, priorities или examples. Отличается от нового framework: profile адаптирует существующую модель, а не создает новую. | `projects/<project-slug>/README.md`, NIST AI RMF profile as external pattern |
+
+## Связи терминов
+
+| Связь | Как понимать |
+| --- | --- |
+| Concept -> Standard | Concept задает смысловые границы; standard превращает повторяющуюся часть этих границ в проверяемый формат. |
+| Policy -> Contract | Policy задает обязательное правило; contract собирает несколько правил, ролей и ожиданий в рабочее соглашение. |
+| Guideline -> Practice -> Standard | Guideline описывает рекомендуемый подход; practice показывает повторяемое применение; standard появляется, когда практику нужно сделать обязательной. |
+| Framework -> Practice | Framework объединяет набор practices и decision rules в методологию для класса задач. |
+| Framework -> Profile | Profile адаптирует framework под контекст без создания конкурирующей методологии. |
+| Artifact -> Canonical / Draft | Artifact имеет lifecycle; canonical artifact действует как источник истины, draft artifact ожидает review. |
+| Operating Mode -> Artifact | Operating Mode задает, какой тип артефакта ожидается и насколько исполнитель может исследовать варианты. |
+| Standard -> Validation | Если standard можно проверить автоматически, правило добавляется в validation script или checklist. |
+
+## Источники и адаптация
+
+| Источник | Что адаптировано для репозитория |
+| --- | --- |
+| [GitHub Docs: rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) | Идея явных, видимых и исполняемых правил репозитория: policies и standards должны быть обнаружимы, а критичные правила желательно связывать с validation или review. |
+| [CNCF governance templates](https://contribute.cncf.io/resources/templates/governance-intro/) | Governance documents должны описывать реальный способ принятия решений, а не имитировать зрелость. Это поддерживает Anti-Inflation principle в [governance/REPO_MODEL.md](../governance/REPO_MODEL.md). |
+| [Scrum Guide 2020](https://scrumguides.org/scrum-guide.html) | Разделение framework, artifacts, commitments и transparency адаптировано для knowledge hub: artifact должен давать reviewable основу для адаптации. |
+| [NIST AI Risk Management Framework 1.0](https://www.nist.gov/itl/ai-risk-management-framework) | Для AI governance взяты идеи govern/map/measure/manage, documented context и profiles как context-specific adaptation. |
+| [RFC 2119 / BCP 14](https://datatracker.ietf.org/doc/rfc2119/) | Уровни обязательности нужно использовать экономно: обязательные слова должны появляться там, где нарушение действительно создает риск или ломает совместимость работы. |

--- a/standards/README.md
+++ b/standards/README.md
@@ -8,6 +8,7 @@
 
 | Стандарт | Статус | Где применяется | Источник |
 | --- | --- | --- | --- |
+| Единый глоссарий терминов | Active | Issues, standards, governance, AI-assisted work | [standards/GLOSSARY.md](GLOSSARY.md) |
 | Концепция репозитория | Active | Root concept и назначение репозитория | [CONCEPT.md](../CONCEPT.md) |
 | AI governance contract | Active | AI-assisted issues, PRs и reviews | [AI_GOVERNANCE.md](../AI_GOVERNANCE.md) |
 | Repository model | Active | Размещение артефактов и правила создания | [governance/REPO_MODEL.md](../governance/REPO_MODEL.md) |
@@ -21,11 +22,13 @@
 
 1. Определите тип артефакта и целевой каталог по
    [governance/REPO_MODEL.md](../governance/REPO_MODEL.md).
-2. Используйте active standard из таблицы, если он уже есть.
-3. Если standard planned, но еще не active, держите артефакт минимальным и
+2. Проверьте терминологию по [standards/GLOSSARY.md](GLOSSARY.md), если
+   документ вводит governance, lifecycle или AI-assisted work terms.
+3. Используйте active standard из таблицы, если он уже есть.
+4. Если standard planned, но еще не active, держите артефакт минимальным и
    объясните gap в issue или PR.
-4. Не добавляйте новый standard только потому, что документ можно
+5. Не добавляйте новый standard только потому, что документ можно
    стандартизировать. Добавляйте его, когда повторяющаяся работа создает
    реальную coordination или review problem.
-5. Ссылайтесь на новый active standard из этой таблицы и ближайшего README или
+6. Ссылайтесь на новый active standard из этой таблицы и ближайшего README или
    governance document.

--- a/tools/validate-repository-structure.sh
+++ b/tools/validate-repository-structure.sh
@@ -38,6 +38,7 @@ is_active_file() {
     CHANGELOG.md | \
     LICENSE | \
     standards/README.md | \
+    standards/GLOSSARY.md | \
     governance/REPO_MODEL.md | \
     .github/ISSUE_TEMPLATE/task.yml | \
     tools/validate-repository-structure.sh)
@@ -73,6 +74,7 @@ required_files=(
   "CHANGELOG.md"
   "LICENSE"
   "standards/README.md"
+  "standards/GLOSSARY.md"
   "governance/REPO_MODEL.md"
   ".github/ISSUE_TEMPLATE/task.yml"
   "tools/validate-repository-structure.sh"
@@ -140,6 +142,27 @@ require_text "CHANGELOG.md" "### Removed"
 
 require_text "standards/README.md" "| Стандарт | Статус | Где применяется | Источник |"
 require_text "standards/README.md" "Как пользоваться"
+require_text "standards/README.md" "standards/GLOSSARY.md"
+
+require_text "standards/GLOSSARY.md" "status: canonical"
+require_text "standards/GLOSSARY.md" "version: 1.0"
+require_text "standards/GLOSSARY.md" "updated: 2026-05-26"
+require_text "standards/GLOSSARY.md" "ai-generated: false"
+require_text "standards/GLOSSARY.md" "Standard"
+require_text "standards/GLOSSARY.md" "Concept"
+require_text "standards/GLOSSARY.md" "Policy"
+require_text "standards/GLOSSARY.md" "Contract"
+require_text "standards/GLOSSARY.md" "Practice"
+require_text "standards/GLOSSARY.md" "Framework"
+require_text "standards/GLOSSARY.md" "Guideline"
+require_text "standards/GLOSSARY.md" "Artifact"
+require_text "standards/GLOSSARY.md" "Canonical"
+require_text "standards/GLOSSARY.md" "Draft"
+require_text "standards/GLOSSARY.md" "Operating Mode"
+require_text "standards/GLOSSARY.md" "Profile"
+require_text "standards/GLOSSARY.md" "Как использовать"
+require_text "standards/GLOSSARY.md" "Связи терминов"
+require_text "standards/GLOSSARY.md" "Источники"
 
 require_text "governance/REPO_MODEL.md" "Артефакт только при операционной боли"
 require_text "governance/REPO_MODEL.md" "Anti-Inflation"


### PR DESCRIPTION
Fixes G-Ivan-A/hybrid-Intelligence-lab#25

## Summary

- Added canonical `standards/GLOSSARY.md` with required frontmatter, 12 core terms, usage rules, term relationships, and source-backed adaptation notes.
- Registered the glossary in `standards/README.md`, root `README.md`, `CONCEPT.md`, and `CHANGELOG.md`.
- Extended `tools/validate-repository-structure.sh` so the glossary and required sections are checked automatically.
- Removed the scaffold `.gitkeep` placeholder from the PR branch.

## Research Sources

- GitHub Docs: repository rulesets — https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets
- CNCF governance templates — https://contribute.cncf.io/resources/templates/governance-intro/
- Scrum Guide 2020 — https://scrumguides.org/scrum-guide.html
- NIST AI Risk Management Framework — https://www.nist.gov/itl/ai-risk-management-framework
- RFC 2119 / BCP 14 — https://datatracker.ietf.org/doc/rfc2119/

## Reproduction / Validation

- Added validator checks before creating the glossary; the check failed on the missing `standards/GLOSSARY.md` and missing registry link.
- Ran `./tools/validate-repository-structure.sh` after the fix: passed.
- Ran `git diff --cached --check` before commit: passed.

## Review Focus

- Whether the term definitions are practical enough for upcoming standards and AI-assisted tasks.
- Whether any term should be split or renamed before this glossary becomes the canonical source of terminology.