### PR TITLE
audit: task execution audit (1-4) + tech debt RFC

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-11T08:37:30.862Z for PR creation at branch issue-213-33925e92e043 for issue https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/213

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-11T08:37:30.862Z for PR creation at branch issue-213-33925e92e043 for issue https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/213

--- a/docs/audit/task-execution-audit-2026-06.md
+++ b/docs/audit/task-execution-audit-2026-06.md
@@ -1,0 +1,215 @@
+# Аудит выполненных задач (1-4)
+
+**Дата:** 2026-06-11
+**Аудитор:** @konard
+**Статус:** Draft
+
+## Область аудита
+
+Аудит покрывает четыре выполненные задачи, перечисленные в issue
+[#213](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/213):
+
+1. Vision/Concept Хаба + гайды + MkDocs.
+2. Обновление шаблона `task.md`.
+3. RFC по HTOM vs spoke.
+4. Анализ JS CI/CD шаблона Константина.
+
+Проверка основана на закрытых issues, merged PR, текущем состоянии `main` и
+локальных проверках репозитория.
+
+## Задача 1: Vision/Concept Хаба + гайды + MkDocs
+
+**Issues:** [#203](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/203),
+[#209](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/209)
+**PR:** [#204](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/204),
+[#210](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/210)
+**Статус:** ✅ Выполнено с замечаниями
+
+### Проверка Definition of Done
+
+- [x] `docs/vision.md` создан и опубликован в MkDocs-навигации.
+- [x] `docs/product-concept.md` создан и опубликован в MkDocs-навигации.
+- [x] `docs/ecosystem-map.md` создан follow-up PR #210.
+- [x] RFC `governance/rfc/hub-vision-concept-proposal-2026-06.md` присутствует.
+- [x] Каталог `guides/` создан и подключён в `mkdocs.yml`.
+- [x] MkDocs-конфигурация есть, сайт собирается из `website/`.
+- [x] GitHub Pages workflow есть: `.github/workflows/deploy-docs.yml`.
+- [x] CSS для таблиц и адаптивности есть: `website/stylesheets/extra.css`.
+- [x] Локальная сборка заявлена в PR #210.
+
+### Findings
+
+- **F1.1: задача #203 была закрыта неполным пакетом и достраивалась issue #209.**
+  Это не блокирует результат сейчас, но показывает, что исходная DoD была
+  выполнена итеративно, а не одним завершённым пакетом.
+- **F1.2: в репозитории остаются сгенерированные HTML-файлы.** Найдены
+  `research/mango/requirements-flow.html`,
+  `research/mango/classification.html`,
+  `research/mango/classification-tz.html`. Это противоречит ограничению issue
+  #213 "не коммитить сгенерированные файлы", если эти HTML считаются build
+  output.
+- **F1.3: `.gitignore` исключает `/site/`, но не исключает `*.html` и `*.png`.**
+  При этом committed PNG-скриншоты лежат в `docs/screenshots/`. Для скриншотов
+  PR #210 это осознанный review artifact, но политика в issue #213 сформулирована
+  шире и требует явного решения.
+- **F1.4: MkDocs публикует только часть репозитория.** Это соответствует
+  комментариям в `mkdocs.yml`, но может быть неожиданным для читателя: governance
+  и standards намеренно не входят в сайт.
+
+### Рекомендации
+
+- Зафиксировать политику generated artifacts: какие HTML/PNG допустимы как
+  исходные артефакты или review evidence, а какие должны попадать только в
+  `/site/` и игнорироваться.
+- Если HTML в `research/mango/` больше не нужен как исходный материал, вынести
+  удаление/миграцию в отдельную cleanup-задачу.
+- Оставить scope MkDocs явным: published docs = `docs/`, `guides/`, `research/`;
+  governance и standards остаются GitHub-first.
+
+## Задача 2: Обновление шаблона `task.md`
+
+**Issue:** [#211](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/211)
+**PR:** [#212](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/212)
+**Статус:** ✅ Выполнено
+
+### Проверка Definition of Done
+
+- [x] `templates/htom/.github/ISSUE_TEMPLATE/task.md` обновлён до полной
+  структуры задачи.
+- [x] `templates/sync-metadata.json` обновлён для Smart Sync.
+- [x] `templates/manifest.json` обновлён через генератор, а не вручную.
+- [x] Структурная и frontmatter-валидация заявлены в PR #212.
+- [x] Все изменённые пути соответствуют kebab-case/действующим исключениям.
+
+### Findings
+
+- **F2.1: решение корректно адаптировало спецификацию под Smart Sync.**
+  PR #212 не редактировал `manifest.json` вручную, а обновил источник
+  `templates/sync-metadata.json` и перегенерировал manifest. Это соответствует
+  архитектуре, введённой issue #207.
+- **F2.2: issue template живёт в `templates/htom/`, а не в старом
+  `templates/spoke/`.** Это ожидаемое следствие разделения HTOM/spoke, но
+  downstream-инструкции должны ссылаться на новый путь.
+
+### Рекомендации
+
+- В future issues явно указывать, что `templates/manifest.json` является
+  generated registry и меняется через `tools/generate-manifest.py`.
+- Для задач по шаблонам добавлять проверку `python3 tools/generate-manifest.py
+  --check` в DoD.
+
+## Задача 3: RFC по HTOM vs spoke
+
+**Issue:** [#201](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/201)
+**PR:** [#206](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/206)
+**Статус:** ✅ Выполнено с остаточным техдолгом
+
+### Проверка Definition of Done
+
+- [x] Создан RFC `governance/rfc/htom-vs-spoke-clarification-2026-06.md`.
+- [x] `templates/spoke/` переосмыслен как шаблон production-spoke.
+- [x] HTOM-геном перенесён в `templates/htom/`.
+- [x] Основные ссылки в governance, standards, templates и README обновлены.
+- [x] Классификация проектов отражена в `projects/README.md`.
+
+### Findings
+
+- **F3.1: концептуальное разделение проведено сквозным рефакторингом.**
+  Текущая структура различает HTOM-команды (`templates/htom/`) и настоящие
+  spoke-репозитории (`templates/spoke/`).
+- **F3.2: техдолг "типы передачи контекста" частично снят, но не закрыт
+  полностью.** Файлы `governance/agent-onboarding-protocol.md` и
+  `templates/htom/AI_SESSION_HANDOVER_PROMPT.md` уже разделены, но нет отдельного
+  стандарта требований к handover prompt.
+- **F3.3: downstream-навигация зависит от Smart Sync.** После переименований
+  spoke/HTOM любые старые ссылки во внешних репозиториях требуют синхронизации
+  или ручной миграции.
+
+### Рекомендации
+
+- Завести отдельную задачу на стандарт `AI_SESSION_HANDOVER_PROMPT.md`: структура,
+  обязательные секции, readback, границы копируемого текста.
+- Добавить Smart Sync verification для шаблонов `templates/htom/` и
+  `templates/spoke/` на fixture-репозитории.
+
+## Задача 4: Анализ JS CI/CD шаблона Константина
+
+**Issue:** [#202](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/202)
+**PR:** [#205](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/205)
+**Статус:** ✅ Выполнено
+
+### Проверка Definition of Done
+
+- [x] Создан research-документ
+  `research/cicd/2026-06-js-cicd-template-analysis.md`.
+- [x] Создан `research/cicd/README.md`.
+- [x] Каталог `research/cicd/` добавлен в структурную модель репозитория.
+- [x] В PR #210 был устранён pre-existing сбой allowlist/ссылки для
+  `research/cicd`.
+
+### Findings
+
+- **F4.1: результат оформлен как research, а не как production workflow.**
+  Это соответствует исследовательскому режиму задачи.
+- **F4.2: интеграция `research/cicd/` в валидатор была доделана последующим PR.**
+  В PR #210 отдельно отмечено исправление pre-existing structure-validator
+  failures, связанных с `research/cicd`.
+- **F4.3: нет отдельного стандарта применения CI/CD шаблона к spoke.**
+  Research фиксирует паттерны, но не превращает их в обязательный контракт.
+
+### Рекомендации
+
+- Не внедрять CI/CD шаблон как стандарт автоматически. Сначала описать
+  минимальный spoke CI contract и критерии применимости.
+- Добавить будущую задачу на сопоставление выводов research/cicd с
+  `templates/spoke/.github/workflows/ci.yml`.
+
+## Проверка техдолга
+
+### Подтверждённый техдолг
+
+| # | Техдолг | Статус | Приоритет |
+| --- | --- | --- | --- |
+| 1 | Разделение онбординга и передачи контекста | Частично снят issue #207 | P1 |
+| 2 | Шаблон задачи для Конарда `templates/task-for-konard.md` | Не найден | P2 |
+| 3 | Стандарт требований к `AI_SESSION_HANDOVER_PROMPT.md` | Не найден | P1 |
+| 4 | Проверка шаблонов в spoke-репо через Smart Sync | Частично покрыто `experiments/test-smart-sync.sh`, нет fixture-spoke CI | P1 |
+| 5 | Политика generated HTML/PNG artifacts | Не формализована | P2 |
+| 6 | Актуализация `governance/backlog.md` после закрытых CE-задач | Требует отдельной проверки: в видимом фрагменте есть TODO для уже закрытых CE issues | P2 |
+
+## Проверка MkDocs и generated artifacts
+
+- `mkdocs.yml` присутствует и использует `website/` как `docs_dir`.
+- `.github/workflows/deploy-docs.yml` присутствует и публикует `/site/` в GitHub
+  Pages.
+- `.gitignore` содержит `/site/`.
+- `.gitignore` не содержит глобальных исключений `*.html` и `*.png`.
+- В репозитории есть committed HTML: `research/mango/*.html`.
+- В репозитории есть committed PNG: `docs/screenshots/*.png`.
+
+Вывод: MkDocs-инфраструктура рабочая, но политика generated artifacts требует
+уточнения. Нельзя одновременно требовать committed screenshots для PR-review и
+абсолютно запрещать PNG без исключений.
+
+## Итоги аудита
+
+**Общая оценка:** хорошо.
+
+Задачи 1-4 в целом выполнены и замержены. Основные проблемы не в отсутствии
+артефактов, а в операционной консистентности: часть DoD закрывалась follow-up
+PR, generated artifacts policy не формализована, а Smart Sync/HTOM-spoke
+изменения требуют downstream-проверок.
+
+### Критические проблемы
+
+- Нет P0-блокеров по текущему состоянию аудируемых задач.
+- Есть P1-техдолг по handover prompt standard и Smart Sync verification.
+
+### Рекомендации
+
+- Сначала закрыть P1-техдолг: стандарт handover prompt и Smart Sync
+  verification.
+- Затем формализовать generated artifacts policy для HTML/PNG.
+- Не менять существующие документы в рамках issue #213 сверх двух новых файлов:
+  это соответствует критическому ограничению issue, несмотря на отдельный пункт
+  про `CHANGELOG.md`.

--- a/governance/rfc/tech-debt-solutions-proposal-2026-06.md
+++ b/governance/rfc/tech-debt-solutions-proposal-2026-06.md
@@ -1,0 +1,228 @@
+# RFC: Предложения по решению техдолга
+
+**Дата:** 2026-06-11
+**Автор:** @konard
+**Статус:** Draft
+
+## Executive Summary
+
+Аудит задач 1-4 показывает, что основные deliverables выполнены, но вокруг них
+накопился операционный техдолг: не до конца формализован handover prompt, Smart
+Sync проверяется локальным experiment script без fixture-spoke контракта,
+политика generated artifacts противоречива, а backlog нуждается в актуализации
+после серии закрытых задач.
+
+Предлагаемое решение: закрыть два P1-долга отдельными малыми задачами, затем
+формализовать правила generated artifacts и обновить backlog как отражение
+факта, а не плана.
+
+## Текущее состояние техдолга
+
+| # | Проблема | Приоритет | Оценка |
+| --- | --- | --- | --- |
+| 1 | Нет стандарта требований к `AI_SESSION_HANDOVER_PROMPT.md` | P1 | M |
+| 2 | Нет fixture-spoke проверки Smart Sync для HTOM/spoke templates | P1 | M |
+| 3 | Не создан `templates/task-for-konard.md` | P2 | S |
+| 4 | Политика generated HTML/PNG artifacts не формализована | P2 | S |
+| 5 | `governance/backlog.md` может не отражать уже закрытые CE-задачи | P2 | M |
+| 6 | Выводы JS CI/CD research не связаны с минимальным spoke CI contract | P3 | M |
+
+## Анализ проблем
+
+### Проблема 1: Handover prompt не имеет отдельного стандарта
+
+**Описание:** `templates/htom/AI_SESSION_HANDOVER_PROMPT.md` существует и
+семантически отделён от onboarding protocol, но требования к его структуре,
+обязательным секциям, readback и границам копируемого текста не вынесены в
+отдельный standard/RFC.
+
+**Влияние:** новые handover prompt изменения будут оцениваться ad hoc, без
+единого review checklist.
+
+**Корневая причина:** issue #207 правильно разделил артефакты, но не должен был
+одновременно создавать полноценный стандарт для каждого из них.
+
+### Проблема 2: Smart Sync не проверяется на реалистичном spoke-fixture
+
+**Описание:** есть `experiments/test-smart-sync.sh`, но нет отдельного
+минимального fixture, который моделирует downstream HTOM/spoke repository и
+проверяет, что шаблоны применяются без порчи локальных правок.
+
+**Влияние:** изменения `templates/htom/`, `templates/spoke/`,
+`templates/sync-metadata.json` и `templates/manifest.json` могут проходить
+локальные проверки, но ломать downstream bootstrap/sync сценарий.
+
+**Корневая причина:** Smart Sync был создан как инфраструктурный пакет, а не как
+полноценная интеграционная test harness для нескольких типов репозиториев.
+
+### Проблема 3: Нет `templates/task-for-konard.md`
+
+**Описание:** issue #213 указывает шаблон задачи для Конарда как техдолг, но
+такого файла в текущем дереве нет.
+
+**Влияние:** задачи для AI-исполнителя продолжают зависеть от issue template и
+ручного контекста, хотя повторяемый формат можно вынести в шаблон.
+
+**Корневая причина:** приоритет был ниже, чем у HTOM/spoke и Smart Sync
+разделения.
+
+### Проблема 4: Политика generated artifacts противоречива
+
+**Описание:** `.gitignore` исключает `/site/`, но не `*.html` или `*.png`. В
+репозитории уже есть committed HTML в `research/mango/` и PNG screenshots в
+`docs/screenshots/`. При этом issue #213 запрещает коммитить generated HTML/PNG.
+
+**Влияние:** review-скриншоты полезны, но без политики каждый PR заново решает,
+является ли PNG исходным evidence artifact или запрещённым generated output.
+
+**Корневая причина:** правила для MkDocs build output, research exports и PR
+review screenshots смешаны в одну категорию "generated files".
+
+### Проблема 5: Backlog может быть неактуален
+
+**Описание:** `governance/backlog.md` содержит CE-задачи со статусом TODO, хотя
+часть соответствующих issues уже закрыта и замержена.
+
+**Влияние:** backlog перестаёт быть источником фактического состояния и требует
+повторной ручной проверки перед планированием.
+
+**Корневая причина:** backlog обновлялся как план, а не синхронизировался после
+каждого merged PR.
+
+### Проблема 6: JS CI/CD research не превращён в spoke CI contract
+
+**Описание:** анализ CI/CD шаблона оформлен как research, но связь с
+`templates/spoke/.github/workflows/ci.yml` и минимальными expectations для
+production-spoke не формализована.
+
+**Влияние:** spoke template остаётся провайдер-агностичным skeleton без
+явного пути развития.
+
+**Корневая причина:** исходная задача была исследовательской, а не
+implementation/standardization task.
+
+## Предложения по решению
+
+### Решение 1: Стандарт `AI_SESSION_HANDOVER_PROMPT.md`
+
+**Описание:** создать короткий standard или RFC, который фиксирует обязательные
+секции handover prompt: назначение, copied block boundaries, required context,
+readback, ограничения, проверка актуальности ссылок.
+
+**Плюсы:** снижает риск разъезда onboarding protocol и handover prompt; даёт
+review checklist.
+
+**Минусы:** добавляет один governance artifact, который нужно поддерживать.
+
+**Оценка:** M
+**Приоритет:** P1
+
+### Решение 2: Fixture-spoke проверка Smart Sync
+
+**Описание:** расширить `experiments/test-smart-sync.sh` или добавить отдельный
+fixture в `experiments/`, который создаёт временный HTOM/spoke repo profile,
+запускает `tools/sync-from-hub.sh --report`, `--apply`, `--force` и проверяет
+локальные правки.
+
+**Плюсы:** ловит реальные регрессии Smart Sync до merge; сохраняет тест как
+исполняемую документацию.
+
+**Минусы:** увеличивает время локальной проверки и требует аккуратного fixture
+cleanup.
+
+**Оценка:** M
+**Приоритет:** P1
+
+### Решение 3: Шаблон задачи для Конарда
+
+**Описание:** создать `templates/task-for-konard.md` как lightweight wrapper над
+issue template: входной контекст, expected autonomy, required checks, PR update
+rules, evidence requirements.
+
+**Плюсы:** уменьшает ручное копирование инструкций в будущих AI-задачах.
+
+**Минусы:** риск дублирования с `.github/ISSUE_TEMPLATE/task.md`, если не
+сделать его тонким и ссылочным.
+
+**Оценка:** S
+**Приоритет:** P2
+
+### Решение 4: Generated artifacts policy
+
+**Описание:** зафиксировать три класса файлов:
+
+- build output: `/site/`, cache, временные exports; не коммитить;
+- source-like research exports: допустимы только если являются самостоятельным
+  артефактом и зарегистрированы;
+- review evidence screenshots: допустимы в `docs/screenshots/` или отдельном
+  agreed path, если нужны PR/issue verification.
+
+**Плюсы:** снимает противоречие между запретом PNG и требованием screenshots в
+визуальных PR.
+
+**Минусы:** требует точного wording, чтобы не открыть дверь для мусорных
+generated files.
+
+**Оценка:** S
+**Приоритет:** P2
+
+### Решение 5: Backlog status refresh
+
+**Описание:** отдельной задачей сверить `governance/backlog.md` с закрытыми
+issues/merged PR и обновить только статусы/ссылки, без добавления новых
+архитектурных планов.
+
+**Плюсы:** возвращает backlog роль factual planning source.
+
+**Минусы:** ручная работа, которую легко снова устарить без правила обновления.
+
+**Оценка:** M
+**Приоритет:** P2
+
+### Решение 6: Minimal spoke CI contract
+
+**Описание:** на основе `research/cicd/2026-06-js-cicd-template-analysis.md`
+описать минимальные expectations для spoke CI: lint/test hooks, dependency
+install policy, provider-neutral defaults, extension points.
+
+**Плюсы:** превращает research в применимый template evolution path.
+
+**Минусы:** преждевременная стандартизация может быть лишней до появления
+нескольких production-spoke.
+
+**Оценка:** M
+**Приоритет:** P3
+
+## Рекомендуемый план действий
+
+**Фаза 1 (срочно):**
+
+- Создать стандарт требований к `AI_SESSION_HANDOVER_PROMPT.md`.
+- Добавить fixture-spoke проверку Smart Sync.
+
+**Фаза 2 (важно):**
+
+- Формализовать generated artifacts policy.
+- Обновить `governance/backlog.md` по фактически закрытым issues.
+- Создать `templates/task-for-konard.md` только если он будет ссылочным, без
+  копирования всего issue template.
+
+**Фаза 3 (желательно):**
+
+- Подготовить minimal spoke CI contract на базе research/cicd.
+- Связать contract с `templates/spoke/.github/workflows/ci.yml`.
+
+## Открытые вопросы
+
+- Должны ли committed research HTML в `research/mango/` считаться исходными
+  артефактами или generated output для удаления?
+- Являются ли screenshots в `docs/screenshots/` постоянной review evidence
+  policy или временным исключением для PR #210?
+- Нужен ли `templates/task-for-konard.md` как отдельный файл, если
+  `templates/htom/.github/ISSUE_TEMPLATE/task.md` уже содержит AI-блок?
+- Должен ли backlog обновляться в каждом PR, закрывающем backlog item, или
+  отдельными periodic audit tasks?
+
+---
+
+**Для обсуждения:** Фаундер, Команда Q


### PR DESCRIPTION
## Что сделано

Fixes G-Ivan-A/hybrid-Intelligence-lab#213.

Созданы два requested Draft-документа:

- `docs/audit/task-execution-audit-2026-06.md` — аудит выполненных задач 1-4 с PR/issue ссылками, DoD-проверкой, findings и рекомендациями.
- `governance/rfc/tech-debt-solutions-proposal-2026-06.md` — RFC по техдолгу с приоритетами, анализом проблем, вариантами решений и phased plan.

Также удалён root `.gitkeep`, созданный bootstrap-коммитом PR и помеченный в этом коммите как временный файл для удаления после завершения задачи.

## Ключевые findings

- Задачи #203/#209, #211, #201, #202 в целом выполнены и замержены.
- Vision/Concept + MkDocs пакет закрывался итеративно: часть DoD из #203 достроена follow-up задачей #209.
- В репозитории есть committed HTML (`research/mango/*.html`) и PNG screenshots (`docs/screenshots/*.png`), при этом `.gitignore` исключает только `/site/`; нужна явная generated artifacts policy.
- HTOM/spoke разделение выполнено, но остаётся P1-техдолг: стандарт `AI_SESSION_HANDOVER_PROMPT.md` и fixture-spoke проверка Smart Sync.
- `CHANGELOG.md` не изменялся намеренно: issue одновременно просит changelog update и задаёт критическое ограничение "только создать два новых файла". В этом PR соблюдён более строгий file-scope constraint для содержательных изменений.

## Проверки

```bash
./tools/validate-frontmatter.sh .
# exit 0; warnings-only, включая два новых Draft markdown без YAML frontmatter

git diff --check
# passed

./tools/validate-repository-structure.sh
# fails because the validator allowlist does not yet include the two new requested files:
# docs/audit/task-execution-audit-2026-06.md
# governance/rfc/tech-debt-solutions-proposal-2026-06.md
```

Я не расширял `tools/validate-repository-structure.sh`, потому что issue #213 задаёт критическое ограничение не менять существующие файлы. Если review решит, что allowlist update важнее этого ограничения, это можно добавить отдельным маленьким commit/PR.
