### PR TITLE
chore: Добавить B-035..B-037 в governance backlog

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-30T18:01:00.651Z for PR creation at branch issue-300-1b9368738dde for issue https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/300

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-30T18:01:00.651Z for PR creation at branch issue-300-1b9368738dde for issue https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/300

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
 status: canonical
-version: 1.22
+version: 1.23
 updated: 2026-06-30
 temperature: 0.1
 ---
@@ -28,6 +28,9 @@ All notable repository governance changes are documented here.
 
 ### Added
 
+- chore: Добавлены задачи B-035..B-037 в бэклог (реорганизация backlog +
+  amendment policy + валидатор). Источники: согласование в чате 2026-06-30,
+  issue #297.
 - analysis: Added `docs/analysis/2026-06-30-backlog-and-artifact-change-policy-analysis.md`
   for issue #297. The report confirms backlog role overload and the missing
   tiered amendment policy, compares native tracker, sprint backlog, small-change

--- a/governance/backlog.md
+++ b/governance/backlog.md
@@ -1,6 +1,6 @@
 ---
 status: canonical
-version: 1.7
+version: 1.8
 updated: 2026-06-30
 temperature: 0.1
 type: backlog
@@ -206,6 +206,9 @@ principle ([governance/repo-model.md](repo-model.md)): **артефакт соз
 | **B-032** | chore: Создание `standards/audit-standard.md` | **P0** | B-031 | TODO | — (planned) | Issue [#296](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/296); будущий ADR B-031 | Нормативный контракт Audit; prerequisite для плана миграции репо и cleanup Audit-артефактов. |
 | **B-033** | chore: Cleanup и модернизация Audit-артефактов | **P2** | B-032 | TODO | — (tech debt) | Issue [#296](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/296); audit-аудит B-029; `standards/audit-standard.md` | Пост-standard cleanup: убрать дубли/конкурирующие файлы, обновить frontmatter, cross-references, artifact-map и индексы. |
 | **B-034** | rfc: План миграции репо Хаба после стандартов Research/Analysis/Audit | **P1** | B-018, B-027, B-032 | TODO | — (planned) | Issue [#296](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/296); ADR-001/ADR-002; будущие R/A/A standards | Фиксирует, что физическая реструктуризация репо — отдельный RFC после всех трёх стандартов, а не этап стандартизации. |
+| **B-035** | Реорганизация `backlog.md` в каталог `pr-ops/backlog/` (contract + active + archive) | **P3** | B-016..B-023, B-034 | TODO | — (tech debt) | Согласование в чате 2026-06-30; issue [#297](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/297) | Текущий монолитный бэклог функционален. Реорганизация — гигиеническая задача после стабилизации research/analysis/audit цепочек. Триггер повышения до P1 — review pain из-за размера бэклога. |
+| **B-036** | Зафиксировать 3-tier amendment policy в `AI_GOVERNANCE.md` | **P2** | — | TODO | — (tech debt) | Согласование в чате 2026-06-30; issue [#297](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/297); [docs/analysis/2026-06-30-backlog-and-artifact-change-policy-analysis.md](../docs/analysis/2026-06-30-backlog-and-artifact-change-policy-analysis.md) | Блокирует корректное выполнение Tier 1/2 правок без бюрократии. Без policy агент будет либо игнорировать малые правки (дрейф), либо запускать полный цикл RFC→ADR на каждое уточнение (паралич). |
+| **B-037** | Обновить `validate-repository-structure.sh` под каталог `pr-ops/backlog/` (2FA-исключение) | **P3** | B-035 | TODO | — (tech debt) | Согласование в чате 2026-06-30; [tools/validate-repository-structure.sh](../tools/validate-repository-structure.sh) | Делает новую структуру бэклога исполнимой. Выполняется после физической реорганизации. |
 
 💡 — креативные задачи, предложенные агентом-исполнителем и не упомянутые во входном
 контексте напрямую (обоснование — в их детальных описаниях).

--- a/tools/validate-repository-structure.sh
+++ b/tools/validate-repository-structure.sh
@@ -1494,7 +1494,7 @@ require_text "governance/session-digests.md" "governance/backlog.md"
 reject_text "governance/session-digests.md" "Конард"
 
 require_text "governance/backlog.md" "status: canonical"
-require_text "governance/backlog.md" "version: 1.7"
+require_text "governance/backlog.md" "version: 1.8"
 require_text "governance/backlog.md" "type: backlog"
 require_text "governance/backlog.md" "standards/glossary.md"
 require_text "governance/backlog.md" "## Открытые вопросы"


### PR DESCRIPTION
## Summary

- Added B-035..B-037 to the main task table in `governance/backlog.md` after B-034.
- Bumped `governance/backlog.md` to version 1.8 and `CHANGELOG.md` to version 1.23.
- Added the requested changelog entry and advanced only the structure validator's pinned backlog version check.

## Scope Notes

This PR does not implement B-035..B-037. It does not reorganize the backlog, does not add the 3-tier amendment policy to `AI_GOVERNANCE.md`, and does not add the future `pr-ops/backlog/` validator exception.

## Validation

- `bash experiments/test-frontmatter-validator.sh`
- `./tools/validate-file-naming.sh`
- `./tools/validate-frontmatter.sh .`
- `./tools/validate-repository-structure.sh`
- `python3 tools/generate-manifest.py --check`
- `git diff --check`

Fixes #300
