### PR TITLE
rfc: уточнить research RFC по гипотезе PR 303

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-30T20:54:04.976Z for PR creation at branch issue-306-fb4f6a0238d6 for issue https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/306

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-30T20:54:04.976Z for PR creation at branch issue-306-fb4f6a0238d6 for issue https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/306

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
 status: canonical
-version: 1.24
+version: 1.25
 updated: 2026-06-30
 temperature: 0.1
 ---
@@ -13,6 +13,10 @@ All notable repository governance changes are documented here.
 
 ### Changed
 
+- rfc: Уточнен `governance/rfc/2026-06-30-rfc-research-structure.md` по issue
+  #306: добавлены явная матрица дельт A/B/C/D и таблица Boundary RFC/ADR для
+  подготовки к ADR B-017. Ошибка генерации PR #303 не подтверждена; гипотеза
+  проблемы признана частично существенной как minor completeness gap.
 - chore: Accepted the ADR/RFC structure RFCs for issue #286 and delegated their
   normative contracts into `standards/adr-structure-standard.md` and
   `standards/rfc-structure-standard.md`. Registered both standards in
@@ -28,6 +32,10 @@ All notable repository governance changes are documented here.
 
 ### Added
 
+- report: Added `reports/report/2026-06-30-pr-303-rfc-hypothesis-analysis.md`
+  for issue #306 with a critical analysis of the attached PR #303 hypothesis,
+  the no-generation-error conclusion, the confirmed minor RFC gaps and the
+  applied remediation.
 - chore: Добавлена задача B-038 в бэклог (Reports inventory). Источник: видение
   фаундера §3, согласование в чате 2026-07-01.
 - rfc: Added `governance/rfc/2026-06-30-rfc-research-structure.md` for issue #302

--- a/governance/rfc/2026-06-30-rfc-research-structure.md
+++ b/governance/rfc/2026-06-30-rfc-research-structure.md
@@ -1,6 +1,6 @@
 ---
 status: draft
-version: 0.1
+version: 0.2
 updated: 2026-06-30
 temperature: 0.1
 owner: G-Ivan-A
@@ -276,6 +276,19 @@ flowchart TD
 - **Совместимость.** Решение не ломает текущий репозиторий: ADR-001 сохраняет
   переходный режим Хаба, а валидаторы не меняются в этом RFC.
 
+## Матрица дельт A/B/C/D
+
+Этот RFC имеет `rfc-scope: A`, потому что меняет базовый контракт Хаба. Матрица
+ниже фиксирует, какие части proposal применяются к другим архетипам как
+downstream input, а не как немедленная норма.
+
+| Архетип | Required deltas | Avoid |
+| --- | --- | --- |
+| A. Governance & Knowledge Hub | Принять или отклонить целевой контракт `research/<domain>/exp/<issue-slug>/`, запрет `outputs/`, routing Research / Analysis / Audit и границу `exp/` vs `runs/` через ADR B-017, стандарт B-018 и addendum B-019. | Не выполнять миграцию `exp-*`, не менять валидаторы research-формата и не превращать RFC в норму до human decision. |
+| B. Prompt & Pattern Library | Если prompt library наследует research-контур Хаба, использовать `exp/` только для воспроизводимой evidence base по prompt experiments; локальные prompt runs остаются в operational records проекта. | Не переносить все prompt experiments в Hub `research/` и не требовать RFC для каждой правки prompt wording. |
+| C. Product Spoke / Runtime | Применять distinction `research evidence` vs `operational run` при проектных исследованиях, migration notes и release-impact анализе; runtime pipeline outputs остаются в `runs/` или локальном CI/artifact storage. | Не смешивать customer/runtime artifacts с Hub research evidence и не навязывать Hub-specific path без project-level ADR/standard. |
+| D. Education / Learning Package | Использовать Research / Analysis / Audit routing для curriculum research, learner-impact analysis и проверки учебных материалов; evidence для course-wide claims может ссылаться на `exp/`. | Не RFC-ить отдельные lesson edits и не превращать учебные отчеты в research corpus без воспроизводимой гипотезы. |
+
 ## Critical Analysis
 
 Стресс-тест предложенных границ: каждую гипотезу пытались опровергнуть.
@@ -365,6 +378,22 @@ Post-acceptance делегирование: обязательная норма 
 `standards/research-standard.md` (B-018) и ADR-002 addendum (B-019). Этот RFC
 сохраняет context, alternatives, trade-offs и rationale; он не дублируется в
 стандарте как proposal-обёртка.
+
+## Boundary RFC/ADR
+
+Для цепочки B-016..B-023 граница такая:
+
+| Case | Rule for this research-structure change |
+| --- | --- |
+| Есть открытые альтернативы по структуре `research/`, контейнеру `exp/`, запрету `outputs/` и routing Research / Analysis / Audit. | Нужен RFC: этот документ сохраняет rationale, alternatives, trade-offs и rejected options. |
+| Human decision должен принять или отклонить proposal перед появлением нормы. | Нужен ADR B-017: короткая запись принятого решения, которая ссылается на этот RFC. |
+| Решение становится обязательным правилом размещения и оформления research artifacts. | Нужен стандарт B-018, а не дальнейшее расширение этого RFC. |
+| Граница `exp/` vs `runs/` затрагивает уже принятый ADR-002. | Нужен ADR-002 addendum B-019 после стандарта, чтобы не создать конкурирующий decision source. |
+| Требуется физическая миграция `exp-*` или изменение валидаторов. | Это implementation follow-up B-022/B-023 после human decision и стандарта, не часть RFC. |
+
+Итог: RFC отвечает на вопрос "какую модель стоит принять?", ADR B-017 отвечает
+"что принято человеком?", а стандарт B-018 и валидаторы отвечают "как исполнять
+это правило повторяемо?".
 
 ## Open Questions
 

--- a/reports/report/2026-06-30-pr-303-rfc-hypothesis-analysis.md
+++ b/reports/report/2026-06-30-pr-303-rfc-hypothesis-analysis.md
@@ -1,0 +1,85 @@
+---
+status: draft
+version: 0.1
+updated: 2026-06-30
+temperature: 0.1
+---
+
+# Отчет по гипотезе проблемы PR #303
+
+## Контекст
+
+Источник задачи: [issue #306](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/306).
+Проверяемый источник проблемы: [PR #303](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/303).
+Гипотеза: приложенный к issue файл `clarify_error_pr_303.txt`.
+
+Проверяемый артефакт PR #303:
+[`governance/rfc/2026-06-30-rfc-research-structure.md`](../../governance/rfc/2026-06-30-rfc-research-structure.md).
+Нормативный контракт проверки:
+[`standards/rfc-structure-standard.md`](../../standards/rfc-structure-standard.md).
+
+## Вердикт
+
+Ошибка генерации RFC не подтверждена: PR #303 был успешно смержен, локальные
+валидаторы и CI для PR #303 проходили, а основной RFC-артефакт существует в
+`main`.
+
+Гипотеза проблемы подтверждена частично. Это не техническая ошибка генерации,
+а minor completeness gap перед ADR B-017: RFC уже содержит обязательный
+`## RFC Metadata`, но не выделял отдельные блоки для матрицы дельт A/B/C/D и
+Boundary RFC/ADR. Эти блоки полезны для review и согласуются с
+`standards/rfc-structure-standard.md`, поэтому RFC доработан.
+
+## Проверка гипотезы
+
+| Утверждение из гипотезы | Результат проверки | Решение |
+| --- | --- | --- |
+| `RFC Metadata` отсутствует как отдельная секция. | Не подтверждено. В смерженном файле есть `## RFC Metadata` сразу после заголовка RFC. | Правка не нужна. |
+| Нет матрицы архетипных дельт A/B/C/D. | Подтверждено. В RFC был только `Archetype scope: A` в metadata, без явной матрицы последствий для B/C/D. | Добавлена секция `## Матрица дельт A/B/C/D`. |
+| P5 слишком детален для RFC. | Не признано ошибкой. Issue #302 прямо просил предложить эвристические критерии классификации; P5 остается proposal-level материалом, а нормативное сжатие уйдет в B-018. | Оставить P5 без упрощения. |
+| Boundary RFC/ADR не выделена таблицей. | Подтверждено как полезное уточнение. Граница была описана в Motivation, Impacted Artifacts и Lifecycle, но не отдельной таблицей. | Добавлена секция `## Boundary RFC/ADR`. |
+
+## Причина расхождения
+
+Причина не в сбое инструмента генерации. PR #303 выполнил DoD issue #302:
+описал `exp/`, запрет `outputs/`, routing Research / Analysis / Audit, границу
+с `runs/`, Critical Analysis и последствия для B-017..B-023.
+
+Расхождение возникло из-за разной интерпретации RFC Structure Standard:
+список required body sections не включает отдельные top-level секции
+`Archetype Deltas` и `Boundary RFC/ADR`, но сам стандарт и recent accepted RFC
+patterns ожидают, что для governance RFC эти аспекты будут явно отражены. Для
+подготовки к ADR B-017 явная форма лучше скрытого упоминания в metadata и
+lifecycle.
+
+## Внесенная доработка
+
+В RFC `governance/rfc/2026-06-30-rfc-research-structure.md`:
+
+- версия draft повышена с `0.1` до `0.2`;
+- добавлена матрица дельт A/B/C/D с границами применения proposal для Hub,
+  prompt/pattern library, product spoke/runtime и education package;
+- добавлена таблица Boundary RFC/ADR для цепочки B-016..B-023;
+- P5 сохранен, потому что эвристики классификации были прямым требованием
+  issue #302 и останутся proposal input для будущего стандарта B-018.
+
+В валидатор структуры добавлены точечные проверки, чтобы эти две секции не
+пропали из research-structure RFC при последующих правках.
+
+## Проверка
+
+Локальная проверка:
+
+```bash
+bash experiments/test-frontmatter-validator.sh      # pass
+./tools/validate-file-naming.sh                     # pass
+./tools/validate-frontmatter.sh .                   # pass
+./tools/validate-repository-structure.sh            # pass
+python3 tools/generate-manifest.py --check          # pass
+bash -n tools/*.sh templates/htom/tools/*.sh templates/spoke/tools/*.sh  # pass
+```
+
+`./tools/validate-mkdocs-site.sh` локально не выполнен до конца: в окружении нет
+`mkdocs` (`mkdocs: command not found`). GitHub Actions workflow устанавливает
+`mkdocs-material` перед этим шагом, поэтому CI остается источником проверки
+сайта.

--- a/tools/validate-repository-structure.sh
+++ b/tools/validate-repository-structure.sh
@@ -47,6 +47,7 @@ is_active_file() {
     AI_PROJECT_CONTEXT-Summary.md | \
     CHANGELOG.md | \
     LICENSE | \
+    reports/report/2026-06-30-pr-303-rfc-hypothesis-analysis.md | \
     docs/adr/2026-06-adr-001-ecosystem-infrastructure-methodology.md | \
     docs/adr/2026-06-adr-002-artifact-document-methodology.md | \
     standards/README.md | \
@@ -815,6 +816,9 @@ require_text "standards/rfc-structure-standard.md" "owner: G-Ivan-A"
 require_text "standards/rfc-structure-standard.md" "frontmatter-docs-standard.md"
 require_text "standards/rfc-structure-standard.md" "rfc-scope"
 require_text "standards/rfc-structure-standard.md" "Open Questions"
+require_text "governance/rfc/2026-06-30-rfc-research-structure.md" "## Матрица дельт A/B/C/D"
+require_text "governance/rfc/2026-06-30-rfc-research-structure.md" "## Boundary RFC/ADR"
+require_text "reports/report/2026-06-30-pr-303-rfc-hypothesis-analysis.md" "Ошибка генерации RFC не подтверждена"
 
 require_text "standards/executable-documentation-standard.md" "status: accepted"
 require_text "standards/executable-documentation-standard.md" "version: 1.2"


### PR DESCRIPTION
## Summary

Fixes G-Ivan-A/hybrid-Intelligence-lab#306.

Critically analyzed the attached `clarify_error_pr_303.txt` hypothesis against merged PR #303 and the current `standards/rfc-structure-standard.md`.

Conclusion: no RFC generation error is confirmed. The hypothesis is partially valid as a minor completeness gap before ADR B-017: the merged RFC already had `## RFC Metadata`, but did not explicitly isolate A/B/C/D deltas and Boundary RFC/ADR as reviewable tables.

## Changes

- Added `reports/report/2026-06-30-pr-303-rfc-hypothesis-analysis.md` with the issue #306 analysis, verdict, claim-by-claim check, root cause, and remediation.
- Updated `governance/rfc/2026-06-30-rfc-research-structure.md` from draft `0.1` to `0.2`:
  - added `## Матрица дельт A/B/C/D`;
  - added `## Boundary RFC/ADR`;
  - kept P5 heuristics because issue #302 explicitly requested classification criteria for the RFC stage.
- Added narrow structure-validator checks so the two new RFC sections and the report verdict stay present.
- Removed the placeholder `.gitkeep` commit artifact.

## Validation

Passed locally:

```bash
bash experiments/test-frontmatter-validator.sh
./tools/validate-file-naming.sh
./tools/validate-frontmatter.sh .
./tools/validate-repository-structure.sh
python3 tools/generate-manifest.py --check
bash -n tools/*.sh templates/htom/tools/*.sh templates/spoke/tools/*.sh
git diff --check
```

Not run locally:

```bash
./tools/validate-mkdocs-site.sh
```

Reason: local environment has no `mkdocs` (`mkdocs: command not found`). The GitHub Actions workflow installs `mkdocs-material` before running this check.

## Review focus

- Whether the report's conclusion correctly classifies PR #303 as no generation error plus a minor RFC completeness gap.
- Whether the added A/B/C/D and Boundary RFC/ADR sections are sufficient for ADR B-017 review without turning the RFC into the future standard B-018.
