### PR TITLE
chore: Синхронизировать backlog и CHANGELOG

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-02T13:52:13.278Z for PR creation at branch issue-333-81ea25567650 for issue https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/333

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-02T13:52:13.278Z for PR creation at branch issue-333-81ea25567650 for issue https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/333

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
 status: canonical
-version: 1.32
+version: 1.33
 updated: 2026-07-02
 temperature: 0.1
 ---
@@ -33,8 +33,8 @@ All notable repository governance changes are documented here.
   Отчёт не предлагает решений, не вводит и не меняет режимы, не создаёт
   стандартов/контрактов. Зарегистрирован в `governance/artifact-map.md`; 21 новый
   внешний источник (`ext-137`…`ext-157`) добавлен в
-  `research/external-knowledge/external-sources-registry.md`; задача B-041 в
-  `governance/backlog.md` со статусом review.
+  `research/external-knowledge/external-sources-registry.md`; задача B-045
+  зарегистрирована в `governance/backlog.md`.
 - rfc: Создан `governance/rfc/2026-07-02-rfc-reports-structure.md` — Draft RFC
   структуры Reports-артефактов (B-041, issue #328). Режим Hybrid: каркас — из
   `standards/rfc-structure-standard.md`, креативная часть (формулировки
@@ -54,7 +54,7 @@ All notable repository governance changes are documented here.
   обязательная норма делегирована в будущий `standards/report-standard.md` (B-043),
   физическая миграция — в B-044. Зарегистрирован в `governance/artifact-map.md`,
   `governance/rfc/README.md` и структурном валидаторе; задачи B-041..B-044
-  добавлены в `governance/backlog.md` (B-041 — статус review).
+  добавлены в `governance/backlog.md`.
 
 - audit: Создан `docs/audit/2026-07-01-documentation-boundary-audit.md` — аудит
   коллизий интерпретации стандартов RFC/ADR/Standard (B-039, issue #320). Аудит
@@ -74,7 +74,7 @@ All notable repository governance changes are documented here.
   относительно canonical глоссария и IL-модели) флагуется для Tier 2 remediation
   в issue #322.
   Зарегистрирован в `governance/artifact-map.md`, `mkdocs.yml` и структурном
-  валидаторе; задача B-039 добавлена в `governance/backlog.md` со статусом review.
+  валидаторе; задача B-039 добавлена в `governance/backlog.md`.
 
 - standard: Создан `standards/research-standard.md` — стандарт (IL-3 reusable
   rule) структуры research-артефактов Хаба (B-018, issue #318). Стандарт принимает
@@ -87,94 +87,14 @@ All notable repository governance changes are documented here.
   для legacy `exp-*`. Стандарт становится replacement для
   `standards/research-profile.md` (физическое удаление профиля — B-021).
   Зарегистрирован в `standards/README.md`, `governance/artifact-map.md` и
-  структурном валидаторе; статус B-018 переведён в review в
+  структурном валидаторе; задача B-018 зарегистрирована в
   `governance/backlog.md`. Alternatives, trade-offs и rejected options не
   дублируются — они остаются в RFC B-016. По review-фидбэку PR #319 стандарт
-  зарегистрирован в `status: draft` (governance-vocabulary, ещё не accepted —
-  идёт review), frontmatter дополнен полями traceability (`executable`, `scope`,
+  зарегистрирован в `status: draft` (governance-vocabulary), frontmatter
+  дополнен полями traceability (`executable`, `scope`,
   `related_standards`, `related_issues`), и явно разведено противоречие
   lifecycle vs frontmatter: `standards/*.md` используют governance-vocabulary, а
   нормируемые research reports (`research/*.md`) — knowledge-vocabulary.
-
-### Changed
-
-- adr: Добавлен addendum B-019 к
-  `docs/adr/2026-06-adr-002-artifact-document-methodology.md` по issue #326.
-  ADR-002 теперь явно фиксирует границу `research/<domain>/exp/<issue-slug>/`
-  (research evidence corpus, всегда связан с parent dated report) vs `runs/`
-  (operational run record, не обязан быть связан с research), включает
-  нормативный критерий «один вопрос исполнителю» и ссылается на ADR-003 как
-  источник решения и RFC B-016 как источник rationale. Routing-таблица ADR-002
-  сохранена без конфликта: строка `Run record` остаётся правилом для
-  operational records, а research evidence routing делегирован
-  `standards/research-standard.md`.
-- adr + standard: Приняты ADR-003 и RFC B-016 по issue #322 / PR #323. Устранены
-  причинные дефекты F-01/F-07/F-07-parallel/F-08 из audit B-039: три structure
-  standards больше не смешивают Standard и Contract; ADR standard получил
-  section-level delegation, минимальный шаблон без invitation to duplicate и
-  acceptance checklist; RFC standard получил Research→RFC delegation и правило
-  обновления `Decision record` / `Implementation link`; backlog, artifact-map,
-  RFC index and CHANGELOG приведены к accepted/status и glossary-aligned
-  terminology.
-- chore: Исправлены точечные последствия audit B-039 по issue #324 после
-  acceptance issue #322. RFC B-016 сохраняет `status: accepted`, `version: 0.3`
-  и `updated: 2026-07-02`; forward-refs `not yet — будущий` заменены
-  фактическими ссылками на ADR-003 и `standards/research-standard.md`. ADR-003
-  сохраняет `status: accepted` и `version: 0.3`; пометка `будущий` у
-  `standards/research-standard.md` убрана. Supersession профиля разграничена:
-  ADR фиксирует human decision, `standards/research-standard.md` задаёт
-  technical replacement, физическое удаление профиля остаётся B-021.
-  `standards/research-standard.md` переведён с `version: 1.1` на draft-aligned
-  `version: 0.1`; `governance/artifact-map.md` синхронизирован с новой
-  формулировкой replacement.
-- adr: Устранено дублирование RFC B-016 в `docs/adr/2026-07-adr-003-research-structure.md`
-  по issue #316 (версия ADR `0.1` → `0.2`, решение и статус `proposed` не
-  изменены). Секция `Decision` больше не пересказывает Proposal P1–P4, а кратко
-  фиксирует «принять модель RFC B-016» со ссылками на разделы RFC; `Alternatives
-  Considered` делегирует полный разбор в RFC вместо копии таблицы; `Consequences`
-  оставляет только архитектурные последствия, а список задач B-018..B-023 отдан
-  RFC Impacted Artifacts и `governance/backlog.md`. `Decision Drivers` сжаты до
-  трёх. RFC B-016 и стандарты ADR/RFC не изменялись (ограничение issue #316).
-- correction: Fixed the placement of the issue #310 deliverables to conform to
-  RFC B-016 v0.2 before merge. Moved the reproducible experiment container from
-  the legacy sibling format `research/hub/exp-reports-inventory-310/` into the
-  target container `research/hub/exp/reports-inventory-310/` (P1) and flattened
-  it — the nested `outputs/` directory was removed so evidence files sit next to
-  the README and script (P2). Moved the inventory itself from
-  `research/hub/2026-07-01-reports-artifacts-inventory.md` to
-  `docs/analysis/2026-07-01-reports-artifacts-inventory.md` because an inventory
-  is an Analysis, not Research (P4 routing). Updated all links, the artifact-map,
-  backlog, research indexes, MkDocs navigation and the structure validator.
-  Recorded the root-cause analysis in
-  `docs/report/2026-07-01-reports-inventory-placement-analysis.md`.
-- backlog: Moved B-038 (Reports inventory and boundaries) from TODO to review,
-  linked issue #310 and PR #312, and recorded `docs/report/` (singular) as the
-  canonical Reports path per founder vision §3 and PR review. Physical migration
-  remains deferred to later Reports standardization and cleanup work.
-- chore: Перенесён report по гипотезе PR #303 из корневого
-  `reports/report/2026-06-30-pr-303-rfc-hypothesis-analysis.md` в canonical
-  `docs/report/2026-06-30-pr-303-rfc-hypothesis-analysis.md` по issue #311.
-  Добавлен frontmatter `owner`, `type`, `context`, `method`, source и related
-  links; корневой каталог `reports/` удалён; registry, MkDocs navigation,
-  file-naming/frontmatter validators and standards updated for `docs/report/`.
-- rfc: Уточнен `governance/rfc/2026-06-30-rfc-research-structure.md` по issue
-  #306: добавлены явная матрица дельт A/B/C/D и таблица Boundary RFC/ADR для
-  подготовки к ADR B-017. Ошибка генерации PR #303 не подтверждена; гипотеза
-  проблемы признана частично существенной как minor completeness gap.
-- chore: Accepted the ADR/RFC structure RFCs for issue #286 and delegated their
-  normative standard rules into `standards/adr-structure-standard.md` and
-  `standards/rfc-structure-standard.md`. Registered both standards in
-  `standards/README.md`, `governance/artifact-map.md`,
-  `governance/rfc/README.md` and the structure validator; added backlog tech debt
-  for frontmatter validator routing, status migration and approved-field policy.
-- correction: Normalized Hub research artifact filenames from `YYYY-MM-name.md`
-  / `YYYY-name.md` to `YYYY-MM-DD-name.md` using git creation dates (issue
-  #271). Updated all repository links, MkDocs navigation, artifact-map entries,
-  the file-naming standards, spoke templates, and validation scripts so
-  research and spoke `docs/analysis/` artifacts sort correctly when there is
-  more than one file per month.
-
-### Added
 
 - report: Added `docs/report/2026-07-01-rfc-adr-duplication-analysis.md` for issue
   #316. Root-cause analysis of the RFC B-016 ↔ ADR-003 duplication: it maps the
@@ -230,8 +150,8 @@ All notable repository governance changes are documented here.
   for issue #306 with a critical analysis of the attached PR #303 hypothesis,
   the no-generation-error conclusion, the confirmed minor RFC gaps and the
   applied remediation.
-- chore: Добавлена задача B-038 в бэклог (Reports inventory). Источник: видение
-  фаундера §3, согласование в чате 2026-07-01.
+- chore: Добавлена задача B-038 в бэклог (Reports inventory, issue #304).
+  Источник: видение фаундера §3, согласование в чате 2026-07-01.
 - rfc: Added `governance/rfc/2026-06-30-rfc-research-structure.md` for issue #302
   (backlog B-016). The RFC proposes the base research-structure model: a single
   `research/<domain>/exp/<issue-slug>/` evidence container, a ban on the nested
@@ -642,96 +562,6 @@ All notable repository governance changes are documented here.
   during task execution. Propagates to project repos via Smart
   Sync of the `templates/htom/AI_SESSION_HANDOVER_PROMPT.md` genome.
 
-### Changed
-
-- creative: добавлен раздел «Периодическая суммаризация сессии» в
-  `templates/htom/AI_SESSION_HANDOVER_PROMPT.md` (порог 30 обращений / ~50К
-  токенов; путь `governance/session-digests.md`; структура контекст/решения/
-  открытые вопросы/следующие шаги; агент инициирует вопрос пользователю только
-  при передаче контекста в чат). Обновлена `governance/artifact-map.md`.
-- structured: strengthened governance contracts for issue #228. Added reverse
-  traceability and `traceability` frontmatter fields to the knowledge lifecycle
-  RFC, constrained resolver scope to routing plus missing-upstream checks,
-  added the Framework vs Template contract to
-  `standards/executable-documentation-standard.md`, normalized operational
-  terminology to `Пользователь` / `агент-исполнитель`, and expanded structure
-  validation coverage for these rules.
-- structured: обновить Vision/Concept + создать knowledge-lifecycle + resolver + универсальные шаблоны.
-- fix: откатить автоматический перевод Draft → Canonical, требуется явное подтверждение Пользователя.
-- Issue #217 PR rebuild (Creative mode): added a separate `practices/` KB for
-  fixed practices; extracted Habr agent-work practices with sources/authors;
-  added international AI governance practice analysis (NIST AI RMF, EU AI Act,
-  ISO/IEC 42001, OpenAI, Anthropic, Google SAIF); introduced
-  `frontmatter-docs-standard.md`, `executable-documentation-standard.md` and
-  `htom-documentation-structure.md`; added
-  `templates/sync-project-with-hub-prompt.md`; refined Vision, Product Concept
-  and Ecosystem Map around practice exchange, multi-chat handover and Hub as a
-  connective layer; updated validators, manifest metadata and artifact map.
-- Issue #217 (Creative mode): audited Hub, `mango_ba_prompts`, `open-ai.ru` and
-  `clarify-engine-ai` against current AI governance practices; reframed the Hub
-  as a recommendation source rather than a blocker; added the four-field
-  `standards/frontmatter-standard.md`; documented Creative override records and
-  AI-agent session semantics; split task authoring into structured
-  `task.md` and creative `task-creative.md` templates for root and HTOM genome;
-  updated validators, manifest metadata and artifact map.
-- Issue #218 (Structured mode): removed generated HTML build artifacts from
-  `research/mango/` and obsolete PNG screenshots from `docs/screenshots/`.
-  Added scoped `.gitignore` rules for those artifact paths and removed the
-  deleted files from repository-structure validation.
-- Issue #215 (Creative mode): separated **Runtime-онбординг** from chat-to-chat
-  context handover and synchronized `AI_SESSION_HANDOVER_PROMPT.md` with a new
-  draft standard. Added `standards/session-handover-standard.md`, updated
-  `docs/ecosystem-map.md` with the ecosystem principle, expanded the canonical
-  `governance/agent-onboarding-protocol.md` and
-  `templates/htom/AI_SESSION_HANDOVER_PROMPT.md` with project-type detection,
-  `Контекст чата диалога`, `Канал взаимодействия с репо`, `Проверка шаблонов`
-  and `Формат постановки задач`. Synced Operating Modes by removing the stale
-  `Project` mode from active AI governance contracts in favour of `Creative`
-  for open-ended project-context work. Extended structural validation to assert
-  the new standard and prompt sections.
-- Issue #207 (Creative mode): semantic separation of the onboarding files into
-  **protocol** (process/checklist) and **artefact** (copyable prompt). Renamed
-  (via `git mv`, history preserved):
-  `governance/agent-onboarding.md` -> `governance/agent-onboarding-protocol.md`
-  (1.1 -> 1.2) and
-  `templates/htom/AI_HANDOVER_PROMPT.md` -> `templates/htom/AI_SESSION_HANDOVER_PROMPT.md`
-  (0.2 -> 0.3). Added disambiguation disclaimers — to the protocol
-  «⚠️ ЭТО ПРОТОКОЛ (ИНСТРУКЦИЯ). Не копируйте в чат.» and to the prompt
-  «⚠️ ЭТО АРТЕФАКТ ДЛЯ КОПИРОВАНИЯ. Скопируйте в новый чат.» Repointed all live
-  references across `README.md`, `AI_GOVERNANCE.md`, `governance/`, `standards/`,
-  `research/`, `templates/htom/` and both validators. NB: the issue proposed
-  `UPPER_CASE` governance paths and a `templates/spoke/` location; both were
-  adapted to the repository's `standards/file-naming.md` (governance uses
-  kebab-case) and the actual genome layout (the handover prompt lives in
-  `templates/htom/`).
-- Issue #201 (Creative mode): clarified the Hub concept by separating
-  **HTOM-команды** (hybrid human + AI work units that inherit the governance
-  genome) from **spoke-репозитории** (production code repositories with their
-  own lifecycle). The minimal governance genome was renamed
-  `templates/spoke/` -> `templates/htom/` (via `git mv`, history preserved),
-  and a new `templates/spoke/` (README.md, CONTRIBUTING.md,
-  `.github/workflows/ci.yml`) was created as the production-spoke template.
-  Migration map (old -> new) for the genome:
-  `templates/spoke/AI_GOVERNANCE.md` -> `templates/htom/AI_GOVERNANCE.md`,
-  `templates/spoke/AI_QUICK_RULES.md` -> `templates/htom/AI_QUICK_RULES.md`,
-  `templates/spoke/AI_HANDOVER_PROMPT.md` -> `templates/htom/AI_HANDOVER_PROMPT.md`,
-  `templates/spoke/README.md` -> `templates/htom/README.md`,
-  `templates/spoke/CONTRIBUTING.md` -> `templates/htom/CONTRIBUTING.md`,
-  `templates/spoke/CHANGELOG.md` -> `templates/htom/CHANGELOG.md`,
-  `templates/spoke/init.sh` -> `templates/htom/init.sh`,
-  `templates/spoke/.github/ISSUE_TEMPLATE/task.md` -> `templates/htom/.github/ISSUE_TEMPLATE/task.md`,
-  `templates/spoke/tools/validate-repository-structure.sh` -> `templates/htom/tools/validate-repository-structure.sh`.
-  Added `governance/rfc/htom-vs-spoke-clarification-2026-06.md` with the
-  definitions, comparison table and current-project classification
-  (Хаб, `repo-development`, `mango_ba_prompts` -> HTOM-команды; `open-ai.ru`
-  -> first real spoke). Repointed genome references across `README.md`,
-  `AI_GOVERNANCE.md`, `governance/repo-model.md`, `governance/artifact-map.md`
-  (1.24 -> 1.25), `standards/glossary.md` (1.2 -> 1.3),
-  `projects/README.md` (1.1 -> 1.2) and validators; extended
-  `tools/validate-repository-structure.sh` to assert both templates.
-
-### Added
-
 - Issue #209 (Creative mode): ecosystem layer for the Hub. New
   `docs/ecosystem-map.md` (full project graph + the **Need-to-Know** principle —
   the Hub keeps the full graph, each project keeps a partial graph via
@@ -838,96 +668,6 @@ All notable repository governance changes are documented here.
   `standards/README.md`, `research/portal/README.md` и структурном валидаторе
   (`is_active_file` + `required_files`); валидатор проходит (exit 0). Решение о
   переводе стандарта в `reviewed`/`canonical` остаётся за Пользователем.
-
-### Changed
-
-- Issue #199: updated `standards/README.md`, `research/README.md`,
-  `governance/artifact-map.md`, `governance/rfc/README.md`,
-  `research/governance/2026-06-06-governance-folder-structure-decisions.md`,
-  `tools/validate-frontmatter.sh` and `tools/validate-repository-structure.sh`
-  for the new L2/L3 webportal standard split and the removal of the active
-  portal package from the Hub.
-- Issue #173: governance-файлы переименованы в kebab-case, правила порядка
-  изложения из бывшего draft body-standard объединены с
-  `standards/research-profile.md`, архив `archive/projects/mango/` удалён после
-  миграции во внешний `mango_ba_prompts`, `standards/file-naming.md` расширен до
-  версии 1.2 для `governance/`, карта артефактов обновлена до 1.20, а
-  структурный валидатор обновлён под новый целевой набор артефактов.
-- Issue #185 (Structured mode): объединены три дублирующих design/standard
-  артефакта с canonical-документами. Rationale протокола онбординга перенесён в
-  `governance/agent-onboarding.md`, rationale ДНК-шаблона — в
-  `templates/spoke/README.md`, body-structure правила research-документов
-  оформлены как `## Body Structure: Введение → Результаты → Детализация` в
-  `standards/research-profile.md` (v1.1). Удалены superseded RFC drafts; ссылки,
-  карта артефактов и структурный валидатор обновлены под новый canonical-набор.
-- Issue #177 (Structured mode): `governance/rfc/repository-quality-improvement-plan.md`
-  обновлён до v0.2: раздел "Full draft list" заменён 52-строчной таблицей
-  с колонками для номера, файла, строки `status: draft`, summary,
-  рекомендации и обоснования. Добавлен "Триаж по категориям" для canonical,
-  отложенных, доработки, объединения и удаления; структурный валидатор теперь
-  ожидает версию RFC 0.2.
-- Issue #169: файлы стандартов внутри `standards/` переименованы из
-  `CAPS_LOCK`/underscore-стиля в kebab-case, все ссылки на старые имена
-  обновлены. `standards/file-naming.md` обновлён до версии 1.1 с явным правилом
-  для `standards/`; `tools/validate-repository-structure.sh` теперь проверяет,
-  что все файлы в `standards/` используют kebab-case, кроме `README.md`,
-  `LICENSE` и `CHANGELOG.md`.
-- Issue #165 (Creative mode): каталог `governance/proposals/` переименован в
-  `governance/rfc/` (решение Q1): имя `rfc/` соответствует файлам `*-rfc.md` и
-  отраслевому термину IETF «RFC», снимая рассинхрон «proposals vs rfc». `git mv`
-  четырёх RFC; обновлены все живые ссылки (`governance/agent-onboarding.md`,
-  `repo-model.md`, `backlog.md`, `executable-documents-issues.md`,
-  `artifact-map.md`, `standards/glossary.md`, `templates/spoke/README.md`,
-  research-документы Хаба и портала, кросс-ссылки внутри RFC). Концепт-RFC
-  портала перенесён `governance/proposals/` →
-  `research/portal/open-ai-portal-concept-rfc.md` (решение Q2: концепция
-  проекта — это research проекта и живёт в `research/{project}/`, а не в
-  governance Хаба; канонический путь без точки в имени каталога по
-  `standards/file-naming.md`). `governance/rfc/` задокументирован как
-  опциональный, не наследуемый споками каталог (решение Q3,
-  `standards/portal-repository-structure.md`). `AI_GOVERNANCE.md` (1.1 → 1.2):
-  зафиксирован слоган Хаба. `governance/artifact-map.md` (1.16 → 1.17):
-  обновлены пути RFC и добавлены строки новых артефактов. Структурный валидатор
-  обновлён под новые пути и проходит (exit 0). Исторические записи (этот
-  CHANGELOG, §7.4 в `contract-executability-rfc.md`, self-report) сохранены как
-  журнал.
-- Issue #141 (CE-004): `AI_GOVERNANCE.md` converted to the executable-documents
-  standard as a reference contract. Added canonical frontmatter with
-  `executable: false`, bumped version to `1.1` and date to `2026-06-04`, and
-  replaced the pre-flight note with a directive pointer to
-  `governance/agent-onboarding.md`. Roles, Operating Modes, escalation and
-  Definition of Done remain unchanged. Structural validation now checks the new
-  frontmatter/version markers; removed the generated harness `.gitkeep`.
-- Issue #140 (CE-003): `templates/spoke/AI_HANDOVER_PROMPT.md` (версия 0.1 →
-  0.2) переведён в стандарт исполнимых документов: во frontmatter добавлен
-  `executable: true`, сразу после frontmatter добавлен директивный блок
-  «🚦 ИСПОЛНИМЫЙ HANDOVER PROMPT — СКОПИРУЙ И ВЫПОЛНИ», готовый prompt с
-  `{{REPO_NAME}}` поднят в блок `▶️ EXECUTION`, а пояснения, источник истины в
-  Хабе и ссылки перенесены в `ℹ️ EXPLANATION` без изменения смысла prompt.
-  Структурный валидатор теперь проверяет CE-003-маркеры и блоки
-  EXECUTION/EXPLANATION; удалён сгенерированный корневой `.gitkeep`, который не
-  является active-файлом репозитория.
-
-- Issue #138 (CE-001): `governance/agent-onboarding.md` (версия 1.0 → 1.1)
-  переведён в стандарт исполнимых документов
-  `governance/proposals/contract-executability-rfc.md` (§5.1, §6.1, §7).
-  Во frontmatter добавлены маркеры `executable: true` и `entrypoint: true`;
-  сразу после frontmatter добавлен директивный блок «🚦 ИСПОЛНИМЫЙ ДОКУМЕНТ — НЕ
-  АНАЛИЗИРУЙ, ВЫПОЛНЯЙ»; содержимое разделено на `▶️ EXECUTION` (Handover Prompt
-  и 4-шаговый протокол) и `ℹ️ EXPLANATION` (модель процесса, threat awareness,
-  перекрёстные ссылки) без потери смысла. Структурный валидатор
-  `tools/validate-repository-structure.sh` обновлён под новую версию/дату и
-  проверяет наличие маркеров и блоков EXECUTION/EXPLANATION.
-
-### Removed
-
-- Issue #199: removed the active `research/portal/` package, the old mixed
-  `standards/webportal-concept-standard.md`, the portal-specific
-  `standards/portal-repository-structure.md`, the old
-  `templates/webportal-concept-template.md` and the generated root `.gitkeep`
-  placeholder.
-
-### Added
 
 - Issue #165 (Creative mode): **зафиксирован слоган Хаба** «Человек задаёт
   смысл, AI ускоряет путь — вместе по правилам» в `README.md`,
@@ -1048,7 +788,279 @@ All notable repository governance changes are documented here.
   Удалён сгенерированный харнессом корневой `.gitkeep` (его нет в `main`),
   снимавший FAIL структурного валидатора.
 
+- Issue #109 (B-001): рабочая инструкция `governance/agent-onboarding.md`
+  (`status: canonical`, тип `правило`) — единый входной артефакт *Runtime-онбординга*
+  (Кейс 1) по утверждённому onboarding-дизайну. Содержит:
+  *Handover Prompt* с плейсхолдером `{{REPO_NAME}}`, 4-шаговый протокол агента
+  (чек-лист governance → чек-лист контекста → *Readback* → стоп до апрува), шаблон
+  *Readback* и раздел threat awareness «Что может пойти не так» (5 рисков холодного
+  старта) — реализация рекомендации команды Q без отдельного файла (Anti-Inflation).
+  Все термины — со ссылкой на `standards/glossary.md`; добавлены перекрёстные ссылки
+  на `templates/spoke/README.md` (Кейс 2) и на RFC-манифест двух кейсов. Граница с
+  design rationale позже упрощена: `agent-onboarding.md` стал и рабочей
+  инструкцией, и canonical-историей решений. Файл зарегистрирован как active в
+  `tools/validate-repository-structure.sh` (`is_active_file`, `required_files` и
+  набор `require_text`) и `governance/artifact-map.md` (версия карты 1.9 → 1.10).
+- Issue #99: RFC-манифест `governance/proposals/rfc-two-cases-of-project-initialization.md`
+  — концептуальное разделение двух ортогональных кейсов инициализации проекта:
+  Кейс 1 (Runtime-онбординг) и Кейс 2 (Bootstrap-клонирование). Ведущая аналогия
+  «сертификация самолёта ≠ лицензия пилота» + анализ ещё трёх смежных областей
+  (медицина, юриспруденция, DevOps) с выводами для модели; таблица-манифест из 13
+  строк; Mermaid-схема жизненного цикла проекта с явным разделением кейсов;
+  обоснование с трассировкой к `research/hub/2026-06-02-ai-collaboration-retrospective.md`;
+  фиксация будущих README по каждому кейсу и follow-up-список. Манифест
+  намеренно не определяет термины — только использует их со ссылкой на глоссарий.
+  Файл зарегистрирован как active в `tools/validate-repository-structure.sh` и
+  `governance/artifact-map.md` (тип `RFC`, версия карты 1.6 → 1.7).
+
 ### Changed
+
+- governance: Синхронизированы `governance/backlog.md` и `CHANGELOG.md` по issue
+  #333 после merged PR #303..#331. В backlog статусы B-018, B-019, B-038,
+  B-039, B-040, B-041 и B-045 приведены к `DONE`, B-019 связан с issue #326 /
+  PR #327, B-038 связан с issue #307 / PR #308 и issue #310 / PR #312,
+  B-041..B-045 упорядочены по номеру, а `Unreleased` в changelog сведён к
+  единственным секциям `Added`, `Changed` и `Removed` без удаления старых
+  записей.
+- adr: Добавлен addendum B-019 к
+  `docs/adr/2026-06-adr-002-artifact-document-methodology.md` по issue #326.
+  ADR-002 теперь явно фиксирует границу `research/<domain>/exp/<issue-slug>/`
+  (research evidence corpus, всегда связан с parent dated report) vs `runs/`
+  (operational run record, не обязан быть связан с research), включает
+  нормативный критерий «один вопрос исполнителю» и ссылается на ADR-003 как
+  источник решения и RFC B-016 как источник rationale. Routing-таблица ADR-002
+  сохранена без конфликта: строка `Run record` остаётся правилом для
+  operational records, а research evidence routing делегирован
+  `standards/research-standard.md`.
+- adr + standard: Приняты ADR-003 и RFC B-016 по issue #322 / PR #323. Устранены
+  причинные дефекты F-01/F-07/F-07-parallel/F-08 из audit B-039: три structure
+  standards больше не смешивают Standard и Contract; ADR standard получил
+  section-level delegation, минимальный шаблон без invitation to duplicate и
+  acceptance checklist; RFC standard получил Research→RFC delegation и правило
+  обновления `Decision record` / `Implementation link`; backlog, artifact-map,
+  RFC index and CHANGELOG приведены к accepted/status и glossary-aligned
+  terminology.
+- chore: Исправлены точечные последствия audit B-039 по issue #324 после
+  acceptance issue #322. RFC B-016 сохраняет `status: accepted`, `version: 0.3`
+  и `updated: 2026-07-02`; forward-refs `not yet — будущий` заменены
+  фактическими ссылками на ADR-003 и `standards/research-standard.md`. ADR-003
+  сохраняет `status: accepted` и `version: 0.3`; пометка `будущий` у
+  `standards/research-standard.md` убрана. Supersession профиля разграничена:
+  ADR фиксирует human decision, `standards/research-standard.md` задаёт
+  technical replacement, физическое удаление профиля остаётся B-021.
+  `standards/research-standard.md` переведён с `version: 1.1` на draft-aligned
+  `version: 0.1`; `governance/artifact-map.md` синхронизирован с новой
+  формулировкой replacement.
+- adr: Устранено дублирование RFC B-016 в `docs/adr/2026-07-adr-003-research-structure.md`
+  по issue #316 (версия ADR `0.1` → `0.2`, решение и статус `proposed` не
+  изменены). Секция `Decision` больше не пересказывает Proposal P1–P4, а кратко
+  фиксирует «принять модель RFC B-016» со ссылками на разделы RFC; `Alternatives
+  Considered` делегирует полный разбор в RFC вместо копии таблицы; `Consequences`
+  оставляет только архитектурные последствия, а список задач B-018..B-023 отдан
+  RFC Impacted Artifacts и `governance/backlog.md`. `Decision Drivers` сжаты до
+  трёх. RFC B-016 и стандарты ADR/RFC не изменялись (ограничение issue #316).
+- correction: Fixed the placement of the issue #310 deliverables to conform to
+  RFC B-016 v0.2 before merge. Moved the reproducible experiment container from
+  the legacy sibling format `research/hub/exp-reports-inventory-310/` into the
+  target container `research/hub/exp/reports-inventory-310/` (P1) and flattened
+  it — the nested `outputs/` directory was removed so evidence files sit next to
+  the README and script (P2). Moved the inventory itself from
+  `research/hub/2026-07-01-reports-artifacts-inventory.md` to
+  `docs/analysis/2026-07-01-reports-artifacts-inventory.md` because an inventory
+  is an Analysis, not Research (P4 routing). Updated all links, the artifact-map,
+  backlog, research indexes, MkDocs navigation and the structure validator.
+  Recorded the root-cause analysis in
+  `docs/report/2026-07-01-reports-inventory-placement-analysis.md`.
+- backlog: Linked B-038 (Reports inventory and boundaries) to issue #310 and PR
+  #312, and recorded `docs/report/` (singular) as the canonical Reports path per
+  founder vision §3 and PR review. Physical migration remains deferred to later
+  Reports standardization and cleanup work.
+- chore: Перенесён report по гипотезе PR #303 из корневого
+  `reports/report/2026-06-30-pr-303-rfc-hypothesis-analysis.md` в canonical
+  `docs/report/2026-06-30-pr-303-rfc-hypothesis-analysis.md` по issue #311.
+  Добавлен frontmatter `owner`, `type`, `context`, `method`, source и related
+  links; корневой каталог `reports/` удалён; registry, MkDocs navigation,
+  file-naming/frontmatter validators and standards updated for `docs/report/`.
+- rfc: Уточнен `governance/rfc/2026-06-30-rfc-research-structure.md` по issue
+  #306: добавлены явная матрица дельт A/B/C/D и таблица Boundary RFC/ADR для
+  подготовки к ADR B-017. Ошибка генерации PR #303 не подтверждена; гипотеза
+  проблемы признана частично существенной как minor completeness gap.
+- chore: Accepted the ADR/RFC structure RFCs for issue #286 and delegated their
+  normative standard rules into `standards/adr-structure-standard.md` and
+  `standards/rfc-structure-standard.md`. Registered both standards in
+  `standards/README.md`, `governance/artifact-map.md`,
+  `governance/rfc/README.md` and the structure validator; added backlog tech debt
+  for frontmatter validator routing, status migration and approved-field policy.
+- correction: Normalized Hub research artifact filenames from `YYYY-MM-name.md`
+  / `YYYY-name.md` to `YYYY-MM-DD-name.md` using git creation dates (issue
+  #271). Updated all repository links, MkDocs navigation, artifact-map entries,
+  the file-naming standards, spoke templates, and validation scripts so
+  research and spoke `docs/analysis/` artifacts sort correctly when there is
+  more than one file per month.
+
+- creative: добавлен раздел «Периодическая суммаризация сессии» в
+  `templates/htom/AI_SESSION_HANDOVER_PROMPT.md` (порог 30 обращений / ~50К
+  токенов; путь `governance/session-digests.md`; структура контекст/решения/
+  открытые вопросы/следующие шаги; агент инициирует вопрос пользователю только
+  при передаче контекста в чат). Обновлена `governance/artifact-map.md`.
+- structured: strengthened governance contracts for issue #228. Added reverse
+  traceability and `traceability` frontmatter fields to the knowledge lifecycle
+  RFC, constrained resolver scope to routing plus missing-upstream checks,
+  added the Framework vs Template contract to
+  `standards/executable-documentation-standard.md`, normalized operational
+  terminology to `Пользователь` / `агент-исполнитель`, and expanded structure
+  validation coverage for these rules.
+- structured: обновить Vision/Concept + создать knowledge-lifecycle + resolver + универсальные шаблоны.
+- fix: откатить автоматический перевод Draft → Canonical, требуется явное подтверждение Пользователя.
+- Issue #217 PR rebuild (Creative mode): added a separate `practices/` KB for
+  fixed practices; extracted Habr agent-work practices with sources/authors;
+  added international AI governance practice analysis (NIST AI RMF, EU AI Act,
+  ISO/IEC 42001, OpenAI, Anthropic, Google SAIF); introduced
+  `frontmatter-docs-standard.md`, `executable-documentation-standard.md` and
+  `htom-documentation-structure.md`; added
+  `templates/sync-project-with-hub-prompt.md`; refined Vision, Product Concept
+  and Ecosystem Map around practice exchange, multi-chat handover and Hub as a
+  connective layer; updated validators, manifest metadata and artifact map.
+- Issue #217 (Creative mode): audited Hub, `mango_ba_prompts`, `open-ai.ru` and
+  `clarify-engine-ai` against current AI governance practices; reframed the Hub
+  as a recommendation source rather than a blocker; added the four-field
+  `standards/frontmatter-standard.md`; documented Creative override records and
+  AI-agent session semantics; split task authoring into structured
+  `task.md` and creative `task-creative.md` templates for root and HTOM genome;
+  updated validators, manifest metadata and artifact map.
+- Issue #218 (Structured mode): removed generated HTML build artifacts from
+  `research/mango/` and obsolete PNG screenshots from `docs/screenshots/`.
+  Added scoped `.gitignore` rules for those artifact paths and removed the
+  deleted files from repository-structure validation.
+- Issue #215 (Creative mode): separated **Runtime-онбординг** from chat-to-chat
+  context handover and synchronized `AI_SESSION_HANDOVER_PROMPT.md` with a new
+  draft standard. Added `standards/session-handover-standard.md`, updated
+  `docs/ecosystem-map.md` with the ecosystem principle, expanded the canonical
+  `governance/agent-onboarding-protocol.md` and
+  `templates/htom/AI_SESSION_HANDOVER_PROMPT.md` with project-type detection,
+  `Контекст чата диалога`, `Канал взаимодействия с репо`, `Проверка шаблонов`
+  and `Формат постановки задач`. Synced Operating Modes by removing the stale
+  `Project` mode from active AI governance contracts in favour of `Creative`
+  for open-ended project-context work. Extended structural validation to assert
+  the new standard and prompt sections.
+- Issue #207 (Creative mode): semantic separation of the onboarding files into
+  **protocol** (process/checklist) and **artefact** (copyable prompt). Renamed
+  (via `git mv`, history preserved):
+  `governance/agent-onboarding.md` -> `governance/agent-onboarding-protocol.md`
+  (1.1 -> 1.2) and
+  `templates/htom/AI_HANDOVER_PROMPT.md` -> `templates/htom/AI_SESSION_HANDOVER_PROMPT.md`
+  (0.2 -> 0.3). Added disambiguation disclaimers — to the protocol
+  «⚠️ ЭТО ПРОТОКОЛ (ИНСТРУКЦИЯ). Не копируйте в чат.» and to the prompt
+  «⚠️ ЭТО АРТЕФАКТ ДЛЯ КОПИРОВАНИЯ. Скопируйте в новый чат.» Repointed all live
+  references across `README.md`, `AI_GOVERNANCE.md`, `governance/`, `standards/`,
+  `research/`, `templates/htom/` and both validators. NB: the issue proposed
+  `UPPER_CASE` governance paths and a `templates/spoke/` location; both were
+  adapted to the repository's `standards/file-naming.md` (governance uses
+  kebab-case) and the actual genome layout (the handover prompt lives in
+  `templates/htom/`).
+- Issue #201 (Creative mode): clarified the Hub concept by separating
+  **HTOM-команды** (hybrid human + AI work units that inherit the governance
+  genome) from **spoke-репозитории** (production code repositories with their
+  own lifecycle). The minimal governance genome was renamed
+  `templates/spoke/` -> `templates/htom/` (via `git mv`, history preserved),
+  and a new `templates/spoke/` (README.md, CONTRIBUTING.md,
+  `.github/workflows/ci.yml`) was created as the production-spoke template.
+  Migration map (old -> new) for the genome:
+  `templates/spoke/AI_GOVERNANCE.md` -> `templates/htom/AI_GOVERNANCE.md`,
+  `templates/spoke/AI_QUICK_RULES.md` -> `templates/htom/AI_QUICK_RULES.md`,
+  `templates/spoke/AI_HANDOVER_PROMPT.md` -> `templates/htom/AI_HANDOVER_PROMPT.md`,
+  `templates/spoke/README.md` -> `templates/htom/README.md`,
+  `templates/spoke/CONTRIBUTING.md` -> `templates/htom/CONTRIBUTING.md`,
+  `templates/spoke/CHANGELOG.md` -> `templates/htom/CHANGELOG.md`,
+  `templates/spoke/init.sh` -> `templates/htom/init.sh`,
+  `templates/spoke/.github/ISSUE_TEMPLATE/task.md` -> `templates/htom/.github/ISSUE_TEMPLATE/task.md`,
+  `templates/spoke/tools/validate-repository-structure.sh` -> `templates/htom/tools/validate-repository-structure.sh`.
+  Added `governance/rfc/htom-vs-spoke-clarification-2026-06.md` with the
+  definitions, comparison table and current-project classification
+  (Хаб, `repo-development`, `mango_ba_prompts` -> HTOM-команды; `open-ai.ru`
+  -> first real spoke). Repointed genome references across `README.md`,
+  `AI_GOVERNANCE.md`, `governance/repo-model.md`, `governance/artifact-map.md`
+  (1.24 -> 1.25), `standards/glossary.md` (1.2 -> 1.3),
+  `projects/README.md` (1.1 -> 1.2) and validators; extended
+  `tools/validate-repository-structure.sh` to assert both templates.
+
+- Issue #199: updated `standards/README.md`, `research/README.md`,
+  `governance/artifact-map.md`, `governance/rfc/README.md`,
+  `research/governance/2026-06-06-governance-folder-structure-decisions.md`,
+  `tools/validate-frontmatter.sh` and `tools/validate-repository-structure.sh`
+  for the new L2/L3 webportal standard split and the removal of the active
+  portal package from the Hub.
+- Issue #173: governance-файлы переименованы в kebab-case, правила порядка
+  изложения из бывшего draft body-standard объединены с
+  `standards/research-profile.md`, архив `archive/projects/mango/` удалён после
+  миграции во внешний `mango_ba_prompts`, `standards/file-naming.md` расширен до
+  версии 1.2 для `governance/`, карта артефактов обновлена до 1.20, а
+  структурный валидатор обновлён под новый целевой набор артефактов.
+- Issue #185 (Structured mode): объединены три дублирующих design/standard
+  артефакта с canonical-документами. Rationale протокола онбординга перенесён в
+  `governance/agent-onboarding.md`, rationale ДНК-шаблона — в
+  `templates/spoke/README.md`, body-structure правила research-документов
+  оформлены как `## Body Structure: Введение → Результаты → Детализация` в
+  `standards/research-profile.md` (v1.1). Удалены superseded RFC drafts; ссылки,
+  карта артефактов и структурный валидатор обновлены под новый canonical-набор.
+- Issue #177 (Structured mode): `governance/rfc/repository-quality-improvement-plan.md`
+  обновлён до v0.2: раздел "Full draft list" заменён 52-строчной таблицей
+  с колонками для номера, файла, строки `status: draft`, summary,
+  рекомендации и обоснования. Добавлен "Триаж по категориям" для canonical,
+  отложенных, доработки, объединения и удаления; структурный валидатор теперь
+  ожидает версию RFC 0.2.
+- Issue #169: файлы стандартов внутри `standards/` переименованы из
+  `CAPS_LOCK`/underscore-стиля в kebab-case, все ссылки на старые имена
+  обновлены. `standards/file-naming.md` обновлён до версии 1.1 с явным правилом
+  для `standards/`; `tools/validate-repository-structure.sh` теперь проверяет,
+  что все файлы в `standards/` используют kebab-case, кроме `README.md`,
+  `LICENSE` и `CHANGELOG.md`.
+- Issue #165 (Creative mode): каталог `governance/proposals/` переименован в
+  `governance/rfc/` (решение Q1): имя `rfc/` соответствует файлам `*-rfc.md` и
+  отраслевому термину IETF «RFC», снимая рассинхрон «proposals vs rfc». `git mv`
+  четырёх RFC; обновлены все живые ссылки (`governance/agent-onboarding.md`,
+  `repo-model.md`, `backlog.md`, `executable-documents-issues.md`,
+  `artifact-map.md`, `standards/glossary.md`, `templates/spoke/README.md`,
+  research-документы Хаба и портала, кросс-ссылки внутри RFC). Концепт-RFC
+  портала перенесён `governance/proposals/` →
+  `research/portal/open-ai-portal-concept-rfc.md` (решение Q2: концепция
+  проекта — это research проекта и живёт в `research/{project}/`, а не в
+  governance Хаба; канонический путь без точки в имени каталога по
+  `standards/file-naming.md`). `governance/rfc/` задокументирован как
+  опциональный, не наследуемый споками каталог (решение Q3,
+  `standards/portal-repository-structure.md`). `AI_GOVERNANCE.md` (1.1 → 1.2):
+  зафиксирован слоган Хаба. `governance/artifact-map.md` (1.16 → 1.17):
+  обновлены пути RFC и добавлены строки новых артефактов. Структурный валидатор
+  обновлён под новые пути и проходит (exit 0). Исторические записи (этот
+  CHANGELOG, §7.4 в `contract-executability-rfc.md`, self-report) сохранены как
+  журнал.
+- Issue #141 (CE-004): `AI_GOVERNANCE.md` converted to the executable-documents
+  standard as a reference contract. Added canonical frontmatter with
+  `executable: false`, bumped version to `1.1` and date to `2026-06-04`, and
+  replaced the pre-flight note with a directive pointer to
+  `governance/agent-onboarding.md`. Roles, Operating Modes, escalation and
+  Definition of Done remain unchanged. Structural validation now checks the new
+  frontmatter/version markers; removed the generated harness `.gitkeep`.
+- Issue #140 (CE-003): `templates/spoke/AI_HANDOVER_PROMPT.md` (версия 0.1 →
+  0.2) переведён в стандарт исполнимых документов: во frontmatter добавлен
+  `executable: true`, сразу после frontmatter добавлен директивный блок
+  «🚦 ИСПОЛНИМЫЙ HANDOVER PROMPT — СКОПИРУЙ И ВЫПОЛНИ», готовый prompt с
+  `{{REPO_NAME}}` поднят в блок `▶️ EXECUTION`, а пояснения, источник истины в
+  Хабе и ссылки перенесены в `ℹ️ EXPLANATION` без изменения смысла prompt.
+  Структурный валидатор теперь проверяет CE-003-маркеры и блоки
+  EXECUTION/EXPLANATION; удалён сгенерированный корневой `.gitkeep`, который не
+  является active-файлом репозитория.
+
+- Issue #138 (CE-001): `governance/agent-onboarding.md` (версия 1.0 → 1.1)
+  переведён в стандарт исполнимых документов
+  `governance/proposals/contract-executability-rfc.md` (§5.1, §6.1, §7).
+  Во frontmatter добавлены маркеры `executable: true` и `entrypoint: true`;
+  сразу после frontmatter добавлен директивный блок «🚦 ИСПОЛНИМЫЙ ДОКУМЕНТ — НЕ
+  АНАЛИЗИРУЙ, ВЫПОЛНЯЙ»; содержимое разделено на `▶️ EXECUTION` (Handover Prompt
+  и 4-шаговый протокол) и `ℹ️ EXPLANATION` (модель процесса, threat awareness,
+  перекрёстные ссылки) без потери смысла. Структурный валидатор
+  `tools/validate-repository-structure.sh` обновлён под новую версию/дату и
+  проверяет наличие маркеров и блоков EXECUTION/EXPLANATION.
 
 - Issue #146 (CE-009): `tools/validate-frontmatter.sh` теперь мягко
   валидирует опциональные маркеры стандарта исполнимых документов:
@@ -1129,35 +1141,6 @@ All notable repository governance changes are documented here.
   разделе 3 (B-013), обновлены `related_issues` во frontmatter и разделы 6/8.
   Удалён сгенерированный харнессом корневой `.gitkeep` (его нет в `main`),
   снимавший FAIL структурного валидатора.
-
-### Added
-
-- Issue #109 (B-001): рабочая инструкция `governance/agent-onboarding.md`
-  (`status: canonical`, тип `правило`) — единый входной артефакт *Runtime-онбординга*
-  (Кейс 1) по утверждённому onboarding-дизайну. Содержит:
-  *Handover Prompt* с плейсхолдером `{{REPO_NAME}}`, 4-шаговый протокол агента
-  (чек-лист governance → чек-лист контекста → *Readback* → стоп до апрува), шаблон
-  *Readback* и раздел threat awareness «Что может пойти не так» (5 рисков холодного
-  старта) — реализация рекомендации команды Q без отдельного файла (Anti-Inflation).
-  Все термины — со ссылкой на `standards/glossary.md`; добавлены перекрёстные ссылки
-  на `templates/spoke/README.md` (Кейс 2) и на RFC-манифест двух кейсов. Граница с
-  design rationale позже упрощена: `agent-onboarding.md` стал и рабочей
-  инструкцией, и canonical-историей решений. Файл зарегистрирован как active в
-  `tools/validate-repository-structure.sh` (`is_active_file`, `required_files` и
-  набор `require_text`) и `governance/artifact-map.md` (версия карты 1.9 → 1.10).
-- Issue #99: RFC-манифест `governance/proposals/rfc-two-cases-of-project-initialization.md`
-  — концептуальное разделение двух ортогональных кейсов инициализации проекта:
-  Кейс 1 (Runtime-онбординг) и Кейс 2 (Bootstrap-клонирование). Ведущая аналогия
-  «сертификация самолёта ≠ лицензия пилота» + анализ ещё трёх смежных областей
-  (медицина, юриспруденция, DevOps) с выводами для модели; таблица-манифест из 13
-  строк; Mermaid-схема жизненного цикла проекта с явным разделением кейсов;
-  обоснование с трассировкой к `research/hub/2026-06-02-ai-collaboration-retrospective.md`;
-  фиксация будущих README по каждому кейсу и follow-up-список. Манифест
-  намеренно не определяет термины — только использует их со ссылкой на глоссарий.
-  Файл зарегистрирован как active в `tools/validate-repository-structure.sh` и
-  `governance/artifact-map.md` (тип `RFC`, версия карты 1.6 → 1.7).
-
-### Changed
 
 - Issue #99: уточнён onboarding-дизайн —
   добавлен раздел «Модель процесса» (без блока терминологии, только ссылки на
@@ -1252,8 +1235,6 @@ All notable repository governance changes are documented here.
   промптов и базы знаний. Пустые папки отслеживаются в Git через `.gitkeep` и
   зарегистрированы как active в `tools/validate-repository-structure.sh`.
 
-### Changed
-
 - Issue #91: рефакторинг структуры `research/` (namespacing). Фундаментальные
   (`scope: repo-wide`) исследования перенесены через `git mv` из корня в новый
   подкаталог `research/hub/` (`2026-05-28-project-context-and-bootstrap-patterns.md`,
@@ -1283,6 +1264,12 @@ All notable repository governance changes are documented here.
   placeholder-точки.
 
 ### Removed
+
+- Issue #199: removed the active `research/portal/` package, the old mixed
+  `standards/webportal-concept-standard.md`, the portal-specific
+  `standards/portal-repository-structure.md`, the old
+  `templates/webportal-concept-template.md` and the generated root `.gitkeep`
+  placeholder.
 
 - Issue #81: повторно удалён служебный корневой `.gitkeep`, восстановленный при
   создании PR-ветки, чтобы `tools/validate-repository-structure.sh` проходил

--- a/governance/backlog.md
+++ b/governance/backlog.md
@@ -1,6 +1,6 @@
 ---
 status: canonical
-version: 1.15
+version: 1.16
 updated: 2026-07-02
 temperature: 0.1
 type: backlog
@@ -55,10 +55,16 @@ related_issues:
   - "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/290"
   - "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/294"
   - "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/296"
+  - "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/302"
   - "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/307"
   - "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/310"
+  - "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/314"
+  - "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/318"
+  - "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/320"
   - "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/322"
+  - "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/326"
   - "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/328"
+  - "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/330"
 ---
 
 # BACKLOG — единый бэклог работ Хаба
@@ -196,10 +202,10 @@ principle ([governance/repo-model.md](repo-model.md)): **артефакт соз
 | **B-013** | 💡 Промоут `backlog.md` в `canonical` и завести issues по утверждённым P1 | **P1** | (этот PR) | DONE | [#107](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/107) | Креативное улучшение агента-исполнителя | Замыкает маршрут «бэклог → issues»; без него бэклог остаётся планом без исполнения. |
 | **B-014** | 💡 Лёгкий «governance health»: регулярный прогон валидаторов + мониторинг триггеров | **P3** | — | TODO | — (отложено) | Креативное улучшение агента-исполнителя | Ценно, но боль возникнет позже; внедряется по триггеру, не сейчас. |
 | **B-015** | RFC: Валидатор frontmatter, миграция статусов и approved list | **P2** | RFC/ADR structure standards | TODO | — (tech debt) | [Ripple Effects 282](../research/hub/2026-06-28-ripple-effects-282-research.md); issue [#286](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/286) | Нужен отдельный RFC/implementation path для routing, status migration, approved fields and CI modes; issue #286 сознательно не меняет validator/migration rules. |
-| **B-016** | RFC: Структура research, контейнер `exp/` и маршрутизация Research/Analysis/Audit | **P0** | — | DONE | [#302](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/302) (accepted через ADR-003; issue [#322](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/322), PR [#323](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/323)) | Issue [#294](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/294); issue [#290](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/290); issue [#288](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/288) | Запустил согласованную цепочку Research → RFC → ADR → Standard и снял неоднозначность `exp-*`/`outputs` vs `runs/` на proposal/decision level. |
-| **B-017** | ADR: Принять стандарт структуры research | **P0** | B-016 | DONE | [#314](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/314) (ADR-003 accepted; issue [#322](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/322), PR [#323](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/323)) | Issue [#294](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/294); RFC B-016 | Фиксирует human decision до стандарта; обязательное правило делегировано в B-018/B-019. |
-| **B-018** | Создать `standards/research-standard.md` как стандарт структуры research | **P0** | B-017 | review | [#318](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/318) (standard в review, PR [#319](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/319)) | Issue [#294](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/294); ADR-003 (B-017) | Заменяет профиль полноценным стандартом: `research/`, `exp/`, запрет `outputs/`, routing по типам задач. |
-| **B-019** | ADR-002 addendum: граница `exp/` vs `runs/` | **P0** | B-018 | TODO | — (planned) | Issue [#294](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/294); [ADR-002](../docs/adr/2026-06-adr-002-artifact-document-methodology.md); issue [#290](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/290) | Устраняет коллизию между research evidence corpus и operational run record. |
+| **B-016** | RFC: Структура research, контейнер `exp/` и маршрутизация Research/Analysis/Audit | **P0** | — | DONE | [#302](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/302) (PR [#303](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/303); accepted через ADR-003: issue [#322](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/322), PR [#323](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/323)) | Issue [#294](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/294); issue [#290](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/290); issue [#288](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/288) | Запустил согласованную цепочку Research → RFC → ADR → Standard и снял неоднозначность `exp-*`/`outputs` vs `runs/` на proposal/decision level. |
+| **B-017** | ADR: Принять стандарт структуры research | **P0** | B-016 | DONE | [#314](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/314) (PR [#315](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/315); ADR-003 accepted: issue [#322](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/322), PR [#323](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/323)) | Issue [#294](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/294); RFC B-016 | Фиксирует human decision до стандарта; обязательное правило делегировано в B-018/B-019. |
+| **B-018** | Создать `standards/research-standard.md` как стандарт структуры research | **P0** | B-017 | DONE | [#318](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/318) (PR [#319](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/319)) | Issue [#294](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/294); ADR-003 (B-017) | Заменяет профиль полноценным стандартом: `research/`, `exp/`, запрет `outputs`, routing по типам задач. |
+| **B-019** | ADR-002 addendum: граница `exp/` vs `runs/` | **P0** | B-018 | DONE | [#326](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/326) (PR [#327](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/327)) | Issue [#294](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/294); [ADR-002](../docs/adr/2026-06-adr-002-artifact-document-methodology.md); issue [#290](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/290) | Устраняет коллизию между research evidence corpus и operational run record. |
 | **B-020** | Обновить `standards/glossary.md`: Research / Analysis / Audit / RFC / ADR / Standard | **P1** | B-019 | TODO | — (planned) | Issue [#294](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/294); issue [#288](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/288) | Закрепляет терминологическую границу, чтобы новые routing-правила не размывались в следующих задачах. |
 | **B-021** | Удалить `standards/research-profile.md` после замены стандартом | **P1** | B-020 | TODO | — (planned) | Issue [#294](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/294); `standards/research-profile.md` | Убирает конкурирующий источник истины; требует CHANGELOG entry и проверки ссылок. |
 | **B-022** | Мигрировать существующие `exp-*` в контейнер `exp/`, убрать `outputs/` | **P2** | B-018, B-019 | TODO | — (tech debt) | Issue [#294](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/294); issue [#290](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/290); текущие `research/hub/exp-*` | Физическая миграция полезна, но должна идти после стандарта, чтобы не закрепить новый дрейф. |
@@ -218,14 +224,14 @@ principle ([governance/repo-model.md](repo-model.md)): **артефакт соз
 | **B-035** | Реорганизация `backlog.md` в каталог `pr-ops/backlog/` (contract + active + archive) | **P3** | B-016..B-023, B-034 | TODO | — (tech debt) | Согласование в чате 2026-06-30; issue [#297](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/297) | Текущий монолитный бэклог функционален. Реорганизация — гигиеническая задача после стабилизации research/analysis/audit цепочек. Триггер повышения до P1 — review pain из-за размера бэклога. |
 | **B-036** | Зафиксировать 3-tier amendment policy в `AI_GOVERNANCE.md` | **P2** | — | TODO | — (tech debt) | Согласование в чате 2026-06-30; issue [#297](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/297); [docs/analysis/2026-06-30-backlog-and-artifact-change-policy-analysis.md](../docs/analysis/2026-06-30-backlog-and-artifact-change-policy-analysis.md) | Блокирует корректное выполнение Tier 1/2 правок без бюрократии. Без policy агент будет либо игнорировать малые правки (дрейф), либо запускать полный цикл RFC→ADR на каждое уточнение (паралич). |
 | **B-037** | Обновить `validate-repository-structure.sh` под каталог `pr-ops/backlog/` (2FA-исключение) | **P3** | B-035 | TODO | — (tech debt) | Согласование в чате 2026-06-30; [tools/validate-repository-structure.sh](../tools/validate-repository-structure.sh) | Делает новую структуру бэклога исполнимой. Выполняется после физической реорганизации. |
-| **B-038** | analysis: Инвентаризация и границы Reports-артефактов (аудит / отчёт / статистика) | **P1** | B-020 | review | [#310](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/310) (PR [#312](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/312)) | Видение фаундера §3 ([research/hub/2026-06-23-repository-structure-concept.md](../research/hub/2026-06-23-repository-structure-concept.md)); согласование в чате 2026-07-01; [Reports inventory](../docs/analysis/2026-07-01-reports-artifacts-inventory.md); [placement report](../docs/report/2026-07-01-reports-inventory-placement-analysis.md) | Reports — базовый подкаталог `docs/`; канонический путь зафиксирован как `docs/report/` (единственное число) по видению фаундера §3 и review PR #312. Inventory готовит границы с Analysis/Audit и scope будущего стандарта перед планом миграции репо (B-034). |
-| **B-039** | audit: Проверка документации на коллизии интерпретации стандартов RFC/ADR/Standard | **P1** | B-017, B-018 | review | [#320](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/320) (PR [#321](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/321)) | Root-cause отчёт [docs/report/2026-07-01-rfc-adr-duplication-analysis.md](../docs/report/2026-07-01-rfc-adr-duplication-analysis.md) (issue #316); `standards/adr-structure-standard.md`, `standards/rfc-structure-standard.md`, `standards/glossary.md`; [audit](../docs/audit/2026-07-01-documentation-boundary-audit.md) | Аудит 5 IL-3 артефактов на дублирование, proposal-обёртку и смешение словарей по трём измерениям. Вердикты без блокеров (ADR-003 ремедиирован); зафиксированы причины (смешение терминов Standard/Contract, шаблон ADR, отсутствие overlap-guard) vs последствия и трёхуровневые рекомендации по лечению причин. Правки артефактов/стандартов — отдельные задачи (Tier 2). |
-| **B-040** | adr + standard: Принять ADR-003 и устранить причинные дефекты стандартов | **P0** | B-039, B-017, B-018 | review | [#322](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/322) (PR [#323](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/323)) | [audit](../docs/audit/2026-07-01-documentation-boundary-audit.md); ADR-003; RFC B-016; `standards/adr-structure-standard.md`; `standards/rfc-structure-standard.md`; `standards/research-standard.md` | Tier 2 remediation причин F-01/F-07/F-07-parallel/F-08: Standard≠Contract, section-level delegation, Research→RFC delegation, metadata placeholder update rule and ADR acceptance checklist. |
-| **B-045** | research: Режимы выполнения задач для ИИ-агентов — индустриальные нормы и паттерны классификации | **P1** | B-016, B-018 | review | [#330](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/330) (PR [#331](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/331)) | Видение фаундера ([research/hub/2026-06-23-repository-structure-concept.md](../research/hub/2026-06-23-repository-structure-concept.md)); `standards/glossary.md` (Operating Mode); [research-отчёт](../research/hub/2026-07-02-task-execution-modes-research.md); [experiment](../research/hub/exp/task-execution-modes-330/README.md) | Research + Creative + Deep Think от лица 4 экспертов: индустриальные нормы (Cynefin/Bloom/Cognitive Load, ReAct/Reflexion/Plan-and-Solve, CrewAI/LangGraph/MetaGPT/AutoGPT, guardrails/evals/HITL), паттерны Hub/Mango и 5 реальных тестов (rule-based классификатор v1→v2). Подтверждает триаду Creative/Structured/Hybrid и action-anchored сигнал как решающий вход. Без предложения решений, новых режимов и стандартов — только исследование, паттерны, тесты, выводы. |
-| **B-041** | rfc: Структура Reports-артефактов (базовый стандарт + профили подтипов + routing) | **P1** | B-038 | review | [#328](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/328) (PR [#329](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/329)) | [Reports inventory](../docs/analysis/2026-07-01-reports-artifacts-inventory.md) (B-038); [Reports industry norms](../research/hub/2026-06-30-reports-industry-norms-and-standardization-scope.md); Видение фаундера §3 ([research/hub/2026-06-23-repository-structure-concept.md](../research/hub/2026-06-23-repository-structure-concept.md)); `standards/rfc-structure-standard.md` | RFC — proposal-вход цепочки стандартизации Reports после инвентаризации B-038: фиксирует Вариант C (базовый стандарт Report + лёгкие профили `audit`/`report`/`statistics`), канонический routing `docs/report/`, relation-метаданные и границы Reports ↔ Analysis ↔ Audit; выносит decision gate (B-042) человеку перед нормативным стандартом (B-043). Зеркалит цепочки Analysis (B-025) и Audit (B-030). |
+| **B-038** | analysis: Инвентаризация и границы Reports-артефактов (аудит / отчёт / статистика) | **P1** | B-020 | DONE | [#307](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/307) (PR [#308](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/308)); [#310](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/310) (PR [#312](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/312)) | Видение фаундера §3 ([research/hub/2026-06-23-repository-structure-concept.md](../research/hub/2026-06-23-repository-structure-concept.md)); согласование в чате 2026-07-01; [Reports inventory](../docs/analysis/2026-07-01-reports-artifacts-inventory.md); [placement report](../docs/report/2026-07-01-reports-inventory-placement-analysis.md) | Reports — базовый подкаталог `docs/`; канонический путь зафиксирован как `docs/report/` (единственное число) по видению фаундера §3 и review PR #312. Inventory готовит границы с Analysis/Audit и scope будущего стандарта перед планом миграции репо (B-034). |
+| **B-039** | audit: Проверка документации на коллизии интерпретации стандартов RFC/ADR/Standard | **P1** | B-017, B-018 | DONE | [#320](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/320) (PR [#321](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/321)) | Root-cause отчёт [docs/report/2026-07-01-rfc-adr-duplication-analysis.md](../docs/report/2026-07-01-rfc-adr-duplication-analysis.md) (issue #316); `standards/adr-structure-standard.md`, `standards/rfc-structure-standard.md`, `standards/glossary.md`; [audit](../docs/audit/2026-07-01-documentation-boundary-audit.md) | Аудит 5 IL-3 артефактов на дублирование, proposal-обёртку и смешение словарей по трём измерениям. Вердикты без блокеров (ADR-003 ремедиирован); зафиксированы причины (смешение терминов Standard/Contract, шаблон ADR, отсутствие overlap-guard) vs последствия и трёхуровневые рекомендации по лечению причин. Правки артефактов/стандартов — отдельные задачи (Tier 2). |
+| **B-040** | adr + standard: Принять ADR-003 и устранить причинные дефекты стандартов | **P0** | B-039, B-017, B-018 | DONE | [#322](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/322) (PR [#323](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/323)) | [audit](../docs/audit/2026-07-01-documentation-boundary-audit.md); ADR-003; RFC B-016; `standards/adr-structure-standard.md`; `standards/rfc-structure-standard.md`; `standards/research-standard.md` | Tier 2 remediation причин F-01/F-07/F-07-parallel/F-08: Standard≠Contract, section-level delegation, Research→RFC delegation, metadata placeholder update rule and ADR acceptance checklist. |
+| **B-041** | rfc: Структура Reports-артефактов (базовый стандарт + профили подтипов + routing) | **P1** | B-038 | DONE | [#328](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/328) (PR [#329](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/329)) | [Reports inventory](../docs/analysis/2026-07-01-reports-artifacts-inventory.md) (B-038); [Reports industry norms](../research/hub/2026-06-30-reports-industry-norms-and-standardization-scope.md); Видение фаундера §3 ([research/hub/2026-06-23-repository-structure-concept.md](../research/hub/2026-06-23-repository-structure-concept.md)); `standards/rfc-structure-standard.md` | RFC — proposal-вход цепочки стандартизации Reports после инвентаризации B-038: фиксирует Вариант C (базовый стандарт Report + лёгкие профили `audit`/`report`/`statistics`), канонический routing `docs/report/`, relation-метаданные и границы Reports ↔ Analysis ↔ Audit; выносит decision gate (B-042) человеку перед нормативным стандартом (B-043). Зеркалит цепочки Analysis (B-025) и Audit (B-030). |
 | **B-042** | adr: Принятие структуры Reports + реконсиляция routing ADR-002 (`docs/reports/` → `docs/report/`) | **P1** | B-041 | TODO | — (planned) | Issue [#328](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/328); будущий RFC B-041 ([governance/rfc/2026-07-02-rfc-reports-structure.md](rfc/2026-07-02-rfc-reports-structure.md)); [ADR-002](../docs/adr/2026-06-adr-002-artifact-document-methodology.md); `standards/adr-structure-standard.md` | Human decision gate: принимает/отклоняет Вариант C и канонический `docs/report/`, реконсилирует строку routing ADR-002 (`docs/reports/` → `docs/report/`) как single decision source перед нормативным стандартом. Зеркалит B-026/B-031. |
 | **B-043** | chore: Создание `standards/report-standard.md` (базовый стандарт Report + профили подтипов) | **P1** | B-042 | TODO | — (planned) | Issue [#328](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/328); будущий ADR B-042; будущий RFC B-041; [Reports industry norms §12](../research/hub/2026-06-30-reports-industry-norms-and-standardization-scope.md) | Нормативно фиксирует базу + профили `audit`/`report`/`statistics`, frontmatter с relation-метаданными, lifecycle (draft → reviewed → canonical → superseded) и routing; делает предложение RFC исполнимым. Prerequisite для cleanup Reports-артефактов. Зеркалит B-027/B-032. |
 | **B-044** | chore: Cleanup и модернизация Reports-артефактов (миграция кандидатов в `docs/report/`) | **P2** | B-043, B-034 | TODO | — (tech debt) | Issue [#328](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/328); [Reports inventory §5](../docs/analysis/2026-07-01-reports-artifacts-inventory.md); будущий standard B-043; план миграции репо B-034 | Пост-standard cleanup: обновить frontmatter (`report-subtype`, relation-поля), убрать дубли/замаскированные отчёты, cross-references, artifact-map и индексы; координируется с планом миграции репо (B-034). Зеркалит B-028/B-033. |
+| **B-045** | research: Режимы выполнения задач для ИИ-агентов — индустриальные нормы и паттерны классификации | **P1** | B-016, B-018 | DONE | [#330](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/330) (PR [#331](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/331)) | Видение фаундера ([research/hub/2026-06-23-repository-structure-concept.md](../research/hub/2026-06-23-repository-structure-concept.md)); `standards/glossary.md` (Operating Mode); [research-отчёт](../research/hub/2026-07-02-task-execution-modes-research.md); [experiment](../research/hub/exp/task-execution-modes-330/README.md) | Research + Creative + Deep Think от лица 4 экспертов: индустриальные нормы (Cynefin/Bloom/Cognitive Load, ReAct/Reflexion/Plan-and-Solve, CrewAI/LangGraph/MetaGPT/AutoGPT, guardrails/evals/HITL), паттерны Hub/Mango и 5 реальных тестов (rule-based классификатор v1→v2). Подтверждает триаду Creative/Structured/Hybrid и action-anchored сигнал как решающий вход. Без предложения решений, новых режимов и стандартов — только исследование, паттерны, тесты, выводы. |
 
 💡 — креативные задачи, предложенные агентом-исполнителем и не упомянутые во входном
 контексте напрямую (обоснование — в их детальных описаниях).
@@ -874,7 +880,7 @@ P0, потому что это обязательный decision gate перед
 [issue #294](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/294);
 ADR-003 (B-017)
 **Зависимости:** B-017
-**Статус:** review (PR [#319](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/319))
+**Статус:** DONE (issue #318 / PR [#319](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/319))
 **Режим работы:** `Structured`
 
 **Контекст:**
@@ -916,10 +922,11 @@ migration и validator не имеют стабильной базы.
 
 **Приоритет:** P0
 **Источник:** 🔗 [issue #294](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/294);
+[issue #326](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/326);
 [ADR-002](../docs/adr/2026-06-adr-002-artifact-document-methodology.md);
 [audit issue #290](../docs/audit/2026-06-29-research-artifact-format-contract-audit.md)
 **Зависимости:** B-018
-**Статус:** TODO
+**Статус:** DONE (issue #326 / PR [#327](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/327))
 **Режим работы:** `Structured`
 
 **Контекст:**
@@ -936,12 +943,12 @@ record.
 4. Указать, как читать legacy `exp-*` до миграции B-022.
 
 **Ожидаемые артефакты:**
-- `docs/adr/2026-06-adr-002-addendum-exp-boundary.md` (новый addendum)
+- `docs/adr/2026-06-adr-002-artifact-document-methodology.md` (addendum B-019)
 
 **Критерии приёмки (DoD):**
-- [ ] Addendum ссылается на ADR-002, standard B-018 и audit #290.
-- [ ] Граница `exp/` vs `runs/` описана без противоречия с routing table ADR-002.
-- [ ] Legacy state и future migration path явно названы.
+- [x] Addendum ссылается на ADR-002, standard B-018 и audit #290.
+- [x] Граница `exp/` vs `runs/` описана без противоречия с routing table ADR-002.
+- [x] Legacy state и future migration path явно названы.
 
 **Обоснование приоритета:**
 P0, потому что именно эта коллизия стала корневой причиной issue #290 и sprint
@@ -1754,7 +1761,7 @@ prompt content.
 - **Внешние источники** `[GAP]`, `[EGA]`, `[AID]` не верифицированы независимо;
   используются как контекст рекомендаций команды С (граница анализа повторяет
   external-review).
-- **Статусы отражают факт на 2026-06-30.** Пересмотр — по триггерам раздела 7.
+- **Статусы отражают факт на 2026-07-02.** Пересмотр — по триггерам раздела 7.
 
 ---
 
@@ -1838,12 +1845,12 @@ Human Review:
 
 ## 10. Зависимости и критический путь
 
-Диаграмма зависимостей задач. B-010, B-008 и B-011 уже выполнены. Активный
-критический путь исходного бэклога ведёт к готовности Runtime-онбординга и
-связанной документации Кейса 2: `B-001 → B-002` и `B-001 → B-005`. Sprint issue
-#294 добавляет отдельный критический путь стандартизации research:
-`B-016 → B-017 → B-018 → B-019 → B-020 → B-021`. B-022 и B-023 — tech debt после
-принятого стандарта и addendum.
+Диаграмма зависимостей задач. B-008, B-010, B-011 и B-016..B-019 уже выполнены.
+Активный критический путь исходного бэклога ведёт к готовности
+Runtime-онбординга и связанной документации Кейса 2: `B-001 → B-002` и
+`B-001 → B-005`. Sprint issue #294 теперь продолжается с glossary/profile
+части: `B-020 → B-021`. B-022 и B-023 — tech debt после принятого стандарта и
+addendum.
 
 Issue #296 добавляет два параллельных sprint chains:
 `B-020 → B-024 → B-025 → B-026 → B-027 → B-028` для Analysis и
@@ -1867,10 +1874,10 @@ flowchart TD
     B013["B-013 · P1<br/>Промоут бэклога<br/>→ issues по P1"]
     B014["B-014 · P3<br/>governance health<br/>(по триггеру)"]
     B015["B-015 · P2<br/>frontmatter validator<br/>migration plan"]
-    B016["B-016 · P0<br/>RFC research structure<br/>exp/ + routing"]
-    B017["B-017 · P0<br/>ADR research structure<br/>human decision"]
-    B018["B-018 · P0<br/>research-standard.md<br/>structure standard"]
-    B019["B-019 · P0<br/>ADR-002 addendum<br/>exp/ vs runs/"]
+    B016["B-016 · DONE<br/>RFC research structure<br/>exp/ + routing"]
+    B017["B-017 · DONE<br/>ADR research structure<br/>human decision"]
+    B018["B-018 · DONE<br/>research-standard.md<br/>structure standard"]
+    B019["B-019 · DONE<br/>ADR-002 addendum<br/>exp/ vs runs/"]
     B020["B-020 · P1<br/>glossary terms<br/>R/A/A + RFC/ADR/Standard"]
     B021["B-021 · P1<br/>remove research-profile.md<br/>after replacement"]
     B022["B-022 · P2<br/>migrate exp-*<br/>remove outputs/"]
@@ -1925,9 +1932,9 @@ flowchart TD
     classDef norm fill:#e0f2fe,stroke:#0369a1,color:#0c4a6e;
     classDef done fill:#dcfce7,stroke:#166534,color:#14532d;
 
-    class B001,B002,B005,B016,B017,B018,B019,B024,B025,B026,B027,B029,B030,B031,B032,B034 crit;
+    class B001,B002,B005,B024,B025,B026,B027,B029,B030,B031,B032,B034 crit;
     class B003,B004,B006,B007,B013,B014,B015,B020,B021,B022,B023,B028,B033 norm;
-    class B008,B010,B011 done;
+    class B008,B010,B011,B016,B017,B018,B019 done;
 ```
 
 Чтение диаграммы: зелёные узлы уже выполнены; жёлтые узлы — активные critical

--- a/tools/validate-repository-structure.sh
+++ b/tools/validate-repository-structure.sh
@@ -1577,7 +1577,7 @@ require_text "governance/session-digests.md" "governance/backlog.md"
 reject_text "governance/session-digests.md" "Конард"
 
 require_text "governance/backlog.md" "status: canonical"
-require_text "governance/backlog.md" "version: 1.15"
+require_text "governance/backlog.md" "version: 1.16"
 require_text "governance/backlog.md" "type: backlog"
 require_text "governance/backlog.md" "standards/glossary.md"
 require_text "governance/backlog.md" "## Открытые вопросы"


### PR DESCRIPTION
## Summary
- Sync governance/backlog.md with the merged issue #302..#330 work: mark B-018, B-019, B-038, B-039, B-040, B-041, and B-045 as DONE; add missing issue/PR links; restore numeric ordering for B-041..B-045.
- Consolidate the current CHANGELOG.md Unreleased block into one Added/Changed/Removed set, add the issue #333 audit entry, and remove stale review-status wording without deleting historical entries.
- Update the structure validator expectation for backlog version 1.16.

Fixes #333.

## Validation
- bash experiments/test-frontmatter-validator.sh
- ./tools/validate-file-naming.sh
- ./tools/validate-frontmatter.sh .
- ./tools/validate-repository-structure.sh
- python3 tools/generate-manifest.py --check