### PR TITLE
fix: Устранить конфляцию Standard и Contract в RFC Reports

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-02T15:45:19.665Z for PR creation at branch issue-332-037dac51a5b4 for issue https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/332

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -815,6 +815,10 @@ All notable repository governance changes are documented here.
 
 ### Changed
 
+- rfc: Устранена терминологическая конфляция F-01 в
+  `governance/rfc/2026-07-02-rfc-reports-structure.md` по issue #332: две
+  конфликтные формулировки заменены на `общий каркас`, чтобы RFC Reports
+  описывал структуру будущего стандарта Report без смешения Standard и Contract.
 - governance: Синхронизированы `governance/backlog.md` и `CHANGELOG.md` по issue
   #333 после merged PR #303..#331. В backlog статусы B-018, B-019, B-038,
   B-039, B-040, B-041 и B-045 приведены к `DONE`, B-019 связан с issue #326 /

--- a/governance/rfc/2026-07-02-rfc-reports-structure.md
+++ b/governance/rfc/2026-07-02-rfc-reports-structure.md
@@ -24,7 +24,7 @@ rfc-scope: A
 ## Summary
 
 Предлагается базовая модель структуры Reports-артефактов Хаба: **один базовый
-стандарт Report** (общий контракт — frontmatter, naming, lifecycle, evidentiary
+стандарт Report** (общий каркас — frontmatter, naming, lifecycle, evidentiary
 stance) плюс **три лёгких профиля подтипов** (`audit`, `report`, `statistics`)
 как секции этого стандарта. Канонический путь размещения — `docs/report/`
 (единственное число). Reports получают frontmatter с relation-метаданными
@@ -121,7 +121,7 @@ Boundary RFC/ADR). Полный бенчмарк и полная матрица 
 ### P1. Базовый стандарт Report (общий каркас)
 
 Предлагается один базовый стандарт `standards/report-standard.md`, фиксирующий
-**общий контракт** durable record of results:
+**общий каркас** durable record of results:
 
 - **Назначение и стойка.** Report — самостоятельный класс по форме (record of
   results) с доминирующей стойкой descriptive («что произошло / что измерено /


### PR DESCRIPTION
## Summary

Fixes G-Ivan-A/hybrid-Intelligence-lab#332.

- Replaced the two F-01 terminology conflicts in `governance/rfc/2026-07-02-rfc-reports-structure.md` with `общий каркас`.
- Added the required `CHANGELOG.md` entry for the RFC Reports terminology fix.
- Kept the RFC content scope unchanged: no routing, frontmatter, proposal, alternative, or trade-off changes.

## Reproduction

Before the fix, the issue's targeted check returned two matches:

```bash
grep -n "общий контракт" governance/rfc/2026-07-02-rfc-reports-structure.md
# 27: ...
# 124: ...
```

After the fix, all issue-required F-01 checks return empty results:

```bash
grep -n "общий контракт" governance/rfc/2026-07-02-rfc-reports-structure.md
grep -n "является нормативным контрактом" governance/rfc/2026-07-02-rfc-reports-structure.md
grep -n "задаёт обязательный контракт" governance/rfc/2026-07-02-rfc-reports-structure.md
```

## Validation

- `./tools/validate-frontmatter.sh .`
- `./tools/validate-file-naming.sh`
- `./tools/validate-repository-structure.sh`
- `python3 tools/generate-manifest.py --check`
- `git diff --check`

No UI changes; screenshots are not applicable.
