### PR TITLE
chore: Ревизия валидаторов после B-048

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Test smart sync
         run: bash tools/test-smart-sync.sh
 
+      - name: Test post-migration validator invariants
+        run: bash tools/test-post-migration-validator.sh
+
       - name: Validate frontmatter
         run: ./tools/validate-frontmatter.sh .
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-04T20:57:51.472Z for PR creation at branch issue-390-cac531c08ad2 for issue https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/390

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-04T20:57:51.472Z for PR creation at branch issue-390-cac531c08ad2 for issue https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/390

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
 status: canonical
-version: 1.47
+version: 1.48
 updated: 2026-07-04
 temperature: 0.1
 ---
@@ -12,6 +12,16 @@ All notable repository governance changes are documented here.
 ## Unreleased
 
 ### Added
+
+- chore: Проведена post-B-048 ревизия валидаторов для issue #390 / B-063
+  (PR #391). `tools/validate-repository-structure.sh` теперь явно отклоняет
+  возвращение retired root paths `governance/`, `website/`, `experiments/` и
+  `mkdocs.yml`; stale self-checks на старые Hub paths заменены на `ai-rules/`
+  и `pr-ops/`. Добавлен `tools/test-post-migration-validator.sh` и отдельный
+  CI-шаг, проверяющий эти инварианты. `tools/validate-frontmatter.sh` и его
+  regression-test покрывают `docs/guides/*.md` как guide-class артефакты.
+  `pr-ops/artifact-map.md`, `pr-ops/backlog.md` и HTOM handover template
+  синхронизированы с ADR-007/B-048 routing.
 
 - chore: Физическая миграция корня Хаба по принятой ADR-007 для issue #384 /
   B-048 (PR #388). Каталог `governance/` физически разделён на `ai-governance/`

--- a/pr-ops/artifact-map.md
+++ b/pr-ops/artifact-map.md
@@ -1,6 +1,6 @@
 ---
 status: canonical
-version: 1.69
+version: 1.70
 updated: 2026-07-04
 temperature: 0.1
 ---
@@ -177,10 +177,11 @@ temperature: 0.1
 | `/standards/education-profile.md` | профиль | — | Профиль образовательных проектов: модули, уроки, упражнения и адаптация форматов. | ✅ Да | `standards/README.md`, `standards/team-contract.md` |
 | `/tools/validate-frontmatter.sh` | утилита | — | Soft-проверка обязательных полей frontmatter в Markdown; для `docs/audit/*.md` дополнительно проверяет knowledge lifecycle, audit-specific поля (`audit_target`/`evidence_model`/`verdict`) и минимальные body-секции. | ✅ Да | `CONTRIBUTING.md`, `standards/README.md`, `standards/frontmatter-docs-standard.md`, `standards/audit-standard.md` |
 | `/tools/validate-file-naming.sh` | утилита | — | Проверка date-first именования Hub `research/`, Hub `docs/report/`, Hub `docs/audit/` и, если они есть, spoke-каталогов `docs/analysis/`, `docs/rfc/`, `docs/adr/`. | ✅ Да | `standards/file-naming.md`, `standards/file-naming-convention.md`, `.github/workflows/validate.yml` |
-| `/tools/validate-repository-structure.sh` | утилита | — | Проверка активной структуры, навигационных ссылок и `-old` миграции. | ✅ Да | `pr-ops/repo-model.md`, `pr-ops/artifact-map.md` |
+| `/tools/validate-repository-structure.sh` | утилита | — | Проверка активной структуры, навигационных ссылок, retired root paths и `-old` миграции. | ✅ Да | `pr-ops/repo-model.md`, `pr-ops/artifact-map.md`, `tools/test-post-migration-validator.sh` |
+| `/tools/test-post-migration-validator.sh` | утилита | — | Регрессионный тест post-B-048: проверяет запрет retired root paths (`governance/`, `website/`, `experiments/`, `mkdocs.yml`) и отсутствие stale validator-assertions на старые пути. | ✅ Да | `tools/validate-repository-structure.sh`, `tools/validate-file-naming.sh`, `.github/workflows/validate.yml`, `docs/adr/2026-07-adr-007-hub-root-structure.md` |
 | `/tools/generate-manifest.py` | утилита | — | Генератор `templates/manifest.json` из дерева `templates/` и `sync-metadata.json`; режимы `--write` (перегенерация) и `--check` (контроль дрейфа). | ✅ Да | `templates/manifest.json`, `templates/sync-metadata.json`, `.github/workflows/update-manifest.yml` |
 | `/tools/sync-from-hub.sh` | утилита | — | Smart Sync клиент: фильтрация шаблонов по `.hub-profile.json` (target_type/stack/min_phase), отчёт и безопасное применение (`.hub-new.*`) либо `--force`-перезапись; `--init` создаёт профиль. | ✅ Да | `templates/manifest.json`, `guides/sync-from-hub.md`, `guides/rollback-sync.md` |
-| `/.github/workflows/validate.yml` | утилита | — | GitHub Action локальных проверок репозитория: bash syntax, frontmatter/smart-sync regression tests, frontmatter, file naming, repository structure и manifest drift. | ✅ Да | `tools/validate-file-naming.sh`, `tools/validate-repository-structure.sh`, `tools/test-frontmatter-validator.sh`, `tools/test-smart-sync.sh` |
+| `/.github/workflows/validate.yml` | утилита | — | GitHub Action локальных проверок репозитория: bash syntax, frontmatter/smart-sync/post-migration regression tests, frontmatter, file naming, repository structure и manifest drift. | ✅ Да | `tools/validate-file-naming.sh`, `tools/validate-repository-structure.sh`, `tools/test-frontmatter-validator.sh`, `tools/test-smart-sync.sh`, `tools/test-post-migration-validator.sh` |
 | `/.github/workflows/update-manifest.yml` | утилита | — | GitHub Action авто-обновления `templates/manifest.json` при push в `main`, затрагивающем `templates/` (коммит `chore: update manifest.json`). | ⚠️ По необходимости | `tools/generate-manifest.py`, `templates/manifest.json` |
 | `/.github/ISSUE_TEMPLATE/task.yml` | шаблон | — | GitHub-native структура постановки задач с operating mode. | ✅ Да | `AI_GOVERNANCE.md`, `standards/glossary.md` |
 | `/.github/ISSUE_TEMPLATE/task.md` | шаблон | — | Structured Markdown-шаблон задачи Хаба для issue, PR и AI-agent traceability. | ✅ Да | `standards/issue-workflow.md`, `AI_GOVERNANCE.md`, `CONTRIBUTING.md` |
@@ -268,7 +269,7 @@ temperature: 0.1
 | `/projects-sink/` | каталог | — | Приёмник контекста spoke-проектов: сводки контекста внешних проектов, синхронизируемые в Хаб. | ✅ Да | `projects-sink/README.md`, `pr-ops/repo-model.md` |
 | `/docs/rfc/` | каталог | — | Корпус RFC Хаба (proposals до human decision); мигрирован из `governance/rfc/` по ADR-007 (B-048). | ✅ Да | `docs/rfc/README.md`, `pr-ops/artifact-map.md`, `standards/rfc-structure-standard.md` |
 | `/docs/guides/` | каталог | — | Зарезервированный якорь для руководств Хаба (ADR-007); наполнение — отдельная задача. | ✅ Да | `docs/guides/README.md`, `pr-ops/repo-model.md` |
-| `/tools/` | каталог | — | Локальные validation и maintenance скрипты. | ✅ Да | `tools/validate-frontmatter.sh`, `tools/validate-repository-structure.sh` |
+| `/tools/` | каталог | — | Локальные validation и maintenance скрипты. | ✅ Да | `tools/validate-frontmatter.sh`, `tools/validate-repository-structure.sh`, `tools/test-post-migration-validator.sh` |
 | `/research/` | каталог | — | Доменные исследования и source-backed analysis; файлы размещаются только в тематических подкаталогах (`hub/`, `mango/`, `governance/`), корень содержит лишь `README.md`. | ✅ Да | `research/README.md`, `standards/research-standard.md`, `pr-ops/repo-model.md` |
 | `/research/hub/` | каталог | — | Фундаментальные исследования работы Хаба (`scope: repo-wide`): bootstrap, governance-стратегия, классификация промптов, RFC/ADR industry norms и архетипные варианты. | ✅ Да | `research/hub/README.md`, `standards/research-standard.md`, `pr-ops/repo-model.md` |
 | `/research/mango/` | каталог | — | Доменные исследования MANGO OFFICE (`scope: mango-only`). | ✅ Да | `research/mango/README.md`, `standards/research-standard.md`, `pr-ops/repo-model.md` |

--- a/pr-ops/backlog.md
+++ b/pr-ops/backlog.md
@@ -1,6 +1,6 @@
 ---
 status: canonical
-version: 1.26
+version: 1.27
 updated: 2026-07-04
 temperature: 0.1
 type: backlog
@@ -281,6 +281,7 @@ principle ([pr-ops/repo-model.md](repo-model.md)): **артефакт созда
 | **B-060** | analysis: Структура и правила наполнения `projects-sink/` | **P3** | B-048 | TODO | — (deferred) | Issue [#380](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/380); B-034 Phase 4; ADR-007; `projects/` intake pain | Triggered research for a managed intake buffer from ecosystem projects; do not create the directory until repeated intake ambiguity appears. |
 | **B-061** | standard: Learning Profile архетипа D для `education/` | **P3** | B-048 | TODO | — (deferred) | Issue [#380](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/380); B-034 §4.3; ADR-007; `standards/education-profile.md` | Deferred until founder initiates an actual course project; then standardize education/Learning Profile boundaries before filling `education/`. |
 | **B-062** | standard: Стандарт фреймворков (архетип A/B) для `frameworks/` | **P3** | B-048 | TODO | — (deferred) | Issue [#380](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/380); B-034 §4.3; ADR-007; current `frameworks/` placeholder | Deferred until the first reusable framework emerges from project methodology; then decide whether `frameworks/` is a Hub capability or spoke/product artifact. |
+| **B-063** | chore: Ревизия валидаторов после физической миграции Хаба | **P2** | B-048 | review | [#390](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/390) (PR [#391](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/391)) | ADR-007/B-048; [artifact map](artifact-map.md); [repo model](repo-model.md); validators | Post-migration audit closes stale validator references to retired root paths, adds regression coverage, and keeps validator registry files synced with the actual ADR-007 tree. |
 
 💡 — креативные задачи, предложенные агентом-исполнителем и не упомянутые во входном
 контексте напрямую (обоснование — в их детальных описаниях).
@@ -2286,6 +2287,37 @@ B-034 §4.3; ADR-007; current `frameworks/` placeholder
 ADR-007 keeps `frameworks/` as a future reusable-framework route. Standardize it
 only after a real framework emerges from Hub methodology and the repository must
 decide whether it is Hub capability material or spoke/product material.
+
+---
+
+### B-063: chore: Ревизия валидаторов после физической миграции Хаба
+
+**Приоритет:** P2
+**Источник:** 🔗 [issue #390](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/390);
+ADR-007/B-048; [pr-ops/artifact-map.md](artifact-map.md);
+[pr-ops/repo-model.md](repo-model.md)
+**Зависимости:** B-048
+**Статус:** review (PR [#391](https://github.com/G-Ivan-A/hybrid-Intelligence-lab/pull/391))
+**Режим работы:** `Structured`
+
+**Контекст:**
+После физической миграции B-048 валидаторы должны отражать новую структуру Хаба:
+`ai-governance/`, `ai-rules/`, `pr-ops/`, `projects-sink/`, `docs/rfc/` и
+`docs/guides/` являются целевыми путями, а root `governance/`, `website/`,
+`experiments/` и `mkdocs.yml` не должны возвращаться как active paths.
+
+**Что сделано в PR #391:**
+- [x] Добавлен regression-test `tools/test-post-migration-validator.sh`.
+- [x] `tools/validate-repository-structure.sh` явно запрещает retired root paths.
+- [x] Stale HTOM/self-check references moved from `governance/` to `ai-rules/`
+      and `pr-ops/`.
+- [x] `docs/guides/*.md` покрыт guide-class frontmatter routing and tests.
+- [x] `CHANGELOG.md`, `pr-ops/artifact-map.md` и этот backlog синхронизированы.
+
+**Критерии приёмки (DoD):**
+- [x] All local validators pass.
+- [x] CI includes the post-migration regression test.
+- [x] No validator self-check requires migrated root `governance/` paths.
 
 ---
 

--- a/templates/htom/AI_SESSION_HANDOVER_PROMPT.md
+++ b/templates/htom/AI_SESSION_HANDOVER_PROMPT.md
@@ -1,6 +1,6 @@
 ---
 status: draft
-version: 0.7
+version: 0.8
 updated: {{date}}
 temperature: 0.1
 executable: true
@@ -10,7 +10,7 @@ executable: true
 > Этот файл — *артефакт* (готовый промпт), а не процесс. Скопируйте блок
 > EXECUTION ниже в начало нового диалога с LLM, чтобы запустить
 > Runtime-онбординг агента. Сам **протокол** (чек-лист и обоснование) живёт
-> отдельно: [governance/agent-onboarding-protocol.md]({{hub_url}}/blob/main/governance/agent-onboarding-protocol.md).
+> отдельно: [ai-rules/agent-onboarding-protocol.md]({{hub_url}}/blob/main/ai-rules/agent-onboarding-protocol.md).
 
 > 🚦 **ИСПОЛНИМЫЙ HANDOVER PROMPT — СКОПИРУЙ И ВЫПОЛНИ.**
 > Я как ИИ-агент в HTOM-команде {{project_name}} должен выполнить готовый Handover
@@ -31,7 +31,7 @@ executable: true
 `hybrid-Intelligence-lab` — источник общих governance-правил, а тип текущего
 проекта нужно определить отдельно: `HTOM-команда` или `Spoke-репозиторий`.
 Прежде чем что-либо менять, выполни Протокол бесшовной передачи проекта
-(governance/agent-onboarding-protocol.md). Это предполётный чек-лист — изменение
+(ai-rules/agent-onboarding-protocol.md). Это предполётный чек-лист — изменение
 файлов запрещено до моего апрува.
 
 Контекст чата диалога:
@@ -52,11 +52,11 @@ executable: true
   в новый чат. Вопрос инициируешь ты, решение — за пользователем.
 - При согласии собери суммарию по структуре: Контекст, Решения, Открытые
   вопросы, Следующие шаги — и предложи сохранить её в
-  governance/session-digests.md (через issue → PR → review, не коммить напрямую).
-- Если в суммарии есть открытые вопросы, добавь их в governance/BACKLOG.md
+  pr-ops/session-digests.md (через issue → PR → review, не коммить напрямую).
+- Если в суммарии есть открытые вопросы, добавь их в pr-ops/backlog.md
   (секция «Открытые вопросы»). Если вопрос уже есть в BACKLOG — не дублируй,
   добавь ссылку на дайджест в секцию/колонку «Связанные дайджесты».
-- При старте нового чата читай сначала индекс governance/session-digests.md,
+- При старте нового чата читай сначала индекс pr-ops/session-digests.md,
   полные суммарии — по необходимости. Не пересказывай контекст из памяти,
   ссылайся на артефакты репозитория.
 
@@ -65,8 +65,8 @@ executable: true
    Spoke-репозиторий или Хаб. Не применяй правила spoke к HTOM-команде без
    явного основания.
 2. Чек-лист governance. Прочитай локальные AI_GOVERNANCE.md, CONTRIBUTING.md и
-   README.md. Если доступны, прочитай governance/repo-model.md,
-   governance/artifact-map.md, standards/project-structure-inheritance.md и
+   README.md. Если доступны, прочитай pr-ops/repo-model.md,
+   pr-ops/artifact-map.md, standards/project-structure-inheritance.md и
    standards/session-handover-standard.md в Хабе или текущем репозитории.
 3. Чек-лист контекста. Прочитай текст issue и последние комментарии, ближайший
    README (репозитория и затронутого проекта/команды) и блок «Быстрый контекст»,
@@ -113,10 +113,10 @@ executable: true
 | Периодическая суммаризация сессии | Отдельный блок перед шагами EXECUTION (только для передачи контекста в чат; не влияет на агента-исполнителя). |
 | Проверка шаблонов | Шаг 4. |
 | Формат постановки задач | Шаг 5. |
-| Протокол бесшовной передачи проекта | Шаги 2-7 и ссылка на `governance/agent-onboarding-protocol.md`. |
+| Протокол бесшовной передачи проекта | Шаги 2-7 и ссылка на `ai-rules/agent-onboarding-protocol.md`. |
 
 > **Источник истины — Хаб.** Канонический *Handover Prompt* и полный 4-шаговый
-> протокол живут в Хабе: [`governance/agent-onboarding-protocol.md`]({{hub_url}}/blob/main/governance/agent-onboarding-protocol.md)
+> протокол живут в Хабе: [`ai-rules/agent-onboarding-protocol.md`]({{hub_url}}/blob/main/ai-rules/agent-onboarding-protocol.md)
 > (Хаб `hybrid-Intelligence-lab`, [{{hub_url}}]({{hub_url}})). Этот файл — **копия
 > шаблона** для удобства HTOM-команды. При расхождении приоритет у хабовой версии
 > и draft-стандарта `standards/session-handover-standard.md`; правки вносятся
@@ -140,8 +140,8 @@ executable: true
   выживанию» агента в этой HTOM-команде.
 - [`AI_GOVERNANCE.md`](AI_GOVERNANCE.md) — конституция проекта: роли, правила,
   эскалация, DoD.
-- Хаб [`governance/agent-onboarding-protocol.md`]({{hub_url}}/blob/main/governance/agent-onboarding-protocol.md)
+- Хаб [`ai-rules/agent-onboarding-protocol.md`]({{hub_url}}/blob/main/ai-rules/agent-onboarding-protocol.md)
   — полный 4-шаговый протокол и канонический *Handover Prompt* (источник истины).
-- Хаб [`governance/session-digests.md`]({{hub_url}}/blob/main/governance/session-digests.md)
+- Хаб [`pr-ops/session-digests.md`]({{hub_url}}/blob/main/pr-ops/session-digests.md)
   — единая точка хранения суммарий сессий для передачи контекста между чатами.
   Механизм только для внешних агентов; агент-исполнитель его не использует.

--- a/templates/htom/README.md
+++ b/templates/htom/README.md
@@ -1,6 +1,6 @@
 ---
 status: canonical
-version: 0.4
+version: 0.5
 updated: {{date}}
 temperature: 0.1
 ---
@@ -133,9 +133,9 @@ grep -RIn '{{[a-z_]*}}' . --exclude-dir=.git   # должно остаться �
 
 | Куда | Зачем |
 | --- | --- |
-| Хаб [`governance/agent-onboarding-protocol.md`]({{hub_url}}/blob/main/governance/agent-onboarding-protocol.md) | **Кейс 1**: протокол *Runtime-онбординга* агента (Handover Prompt, Readback, стоп до апрува). |
+| Хаб [`ai-rules/agent-onboarding-protocol.md`]({{hub_url}}/blob/main/ai-rules/agent-onboarding-protocol.md) | **Кейс 1**: протокол *Runtime-онбординга* агента (Handover Prompt, Readback, стоп до апрува). |
 | Хаб [`standards/session-handover-standard.md`]({{hub_url}}/blob/main/standards/session-handover-standard.md) | Draft-стандарт структуры `AI_SESSION_HANDOVER_PROMPT.md`: контекст проекта, чат-диалог, канал репо и проверка шаблонов. |
-| Хаб [`rfc-two-cases-of-project-initialization.md`]({{hub_url}}/blob/main/governance/rfc/rfc-two-cases-of-project-initialization.md) | Манифест двух кейсов: чем Кейс 2 (этот файл) отличается от Кейса 1. |
+| Хаб [`rfc-two-cases-of-project-initialization.md`]({{hub_url}}/blob/main/docs/rfc/rfc-two-cases-of-project-initialization.md) | Манифест двух кейсов: чем Кейс 2 (этот файл) отличается от Кейса 1. |
 | Этот README, раздел [Design Decisions & Rationale](#design-decisions--rationale) | Дизайн «ДНК-шаблона» HTOM-команды: почему геном именно такой. |
 
 ## Design Decisions & Rationale

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": "1.0",
-  "last_updated": "2026-06-25",
+  "last_updated": "2026-07-04",
   "templates": [
     {
       "id": "htom-issue-template-task-creative",
@@ -81,7 +81,7 @@
     {
       "id": "htom-ai-session-handover-prompt",
       "path": "templates/htom/AI_SESSION_HANDOVER_PROMPT.md",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "target_type": [
         "HTOM",
         "Spoke"
@@ -136,7 +136,7 @@
     {
       "id": "htom-readme",
       "path": "templates/htom/README.md",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "target_type": [
         "HTOM"
       ],

--- a/tools/test-frontmatter-validator.sh
+++ b/tools/test-frontmatter-validator.sh
@@ -81,6 +81,7 @@ make_tmp_dir knowledge_dir research
 make_tmp_dir governance_dir standards
 make_tmp_dir adr_dir docs/adr
 make_tmp_dir rfc_dir docs/rfc
+make_tmp_file guide_doc docs/guides
 make_tmp_file report_doc docs/report
 make_tmp_file audit_doc docs/audit
 make_tmp_file audit_missing_target_doc docs/audit
@@ -139,6 +140,15 @@ severity_scale: Critical/Major/Minor/Info
 follow_up: none
 related_norm: standards/audit-standard.md" "$audit_body"
 expect_pass "valid docs/audit metadata" "$audit_doc"
+
+write_doc "$guide_doc" "status: draft
+version: 1.0
+updated: 2026-07-04
+temperature: 0.1
+audience: maintainers
+entrypoint: true
+executable: false"
+expect_pass "valid docs/guides metadata" "$guide_doc"
 
 write_doc "$governance_dir/valid.md" "status: accepted
 version: 1.0

--- a/tools/test-post-migration-validator.sh
+++ b/tools/test-post-migration-validator.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+tmp_out="$(mktemp)"
+tmp_err="$(mktemp)"
+
+cleanup() {
+  rm -rf governance website experiments mkdocs.yml "$tmp_out" "$tmp_err"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'ERROR: %s\n' "$1" >&2
+  if [[ -s "$tmp_out" ]]; then
+    printf '\nstdout:\n' >&2
+    cat "$tmp_out" >&2
+  fi
+  if [[ -s "$tmp_err" ]]; then
+    printf '\nstderr:\n' >&2
+    cat "$tmp_err" >&2
+  fi
+  exit 1
+}
+
+for legacy_path in governance website experiments mkdocs.yml; do
+  if [[ -e "$legacy_path" ]]; then
+    fail "cannot run legacy-path test while $legacy_path already exists"
+  fi
+done
+
+mkdir governance website experiments
+: > mkdocs.yml
+
+if ./tools/validate-repository-structure.sh >"$tmp_out" 2>"$tmp_err"; then
+  fail "expected repository structure validator to reject ADR-007 legacy root paths"
+fi
+
+for expected in \
+  "forbidden legacy path present: governance" \
+  "forbidden legacy path present: website" \
+  "forbidden legacy path present: experiments" \
+  "forbidden legacy path present: mkdocs.yml"; do
+  if ! grep -Fq "$expected" "$tmp_err"; then
+    fail "missing expected validator error: $expected"
+  fi
+done
+
+cleanup
+trap - EXIT
+
+if grep -nE 'require_text[[:space:]]+"[^"]+"[[:space:]]+"governance/' tools/validate-repository-structure.sh; then
+  fail "structure validator must not require migrated root governance/ paths"
+fi
+
+if grep -nF 'governance/rfc/' tools/validate-file-naming.sh; then
+  fail "file-naming validator must not keep stale governance/rfc/ comments"
+fi
+
+for required_path in \
+  "projects-sink" \
+  "ai-governance" \
+  "ai-rules" \
+  "pr-ops" \
+  "docs/rfc" \
+  "docs/guides"; do
+  if ! grep -Fq "\"$required_path\"" tools/validate-repository-structure.sh; then
+    fail "structure validator must require ADR-007 path: $required_path"
+  fi
+done
+
+printf 'Post-migration validator regression tests passed.\n'

--- a/tools/validate-file-naming.sh
+++ b/tools/validate-file-naming.sh
@@ -87,8 +87,8 @@ validate_tree "docs/audit" "is_daily_chronological_name" "YYYY-MM-DD-name.md"
 # rfc-structure-standard.md the Hub RFC rule is `YYYY-MM-DD-rfc-*` for new dated
 # RFCs while legacy names stay unchanged (descriptive). The `YYYY-MM`/`YYYY`
 # monthly rule (standards/file-naming.md) is the spoke rule; enforcing it here
-# would reject the Hub's own standard-compliant legacy RFC corpus migrated from
-# governance/rfc/ under ADR-007 (B-048).
+# would reject the Hub's own standard-compliant legacy RFC corpus after the
+# ADR-007/B-048 migration.
 validate_tree "docs/adr" "is_adr_chronological_name" "YYYY-MM-adr-NNN-name.md"
 
 if (( failures > 0 )); then

--- a/tools/validate-frontmatter.sh
+++ b/tools/validate-frontmatter.sh
@@ -98,7 +98,7 @@ document_class() {
     templates/*.md | templates/*/*.md | templates/*/*/*.md)
       printf 'template'
       ;;
-    guides/*.md)
+    guides/*.md | docs/guides/*.md)
       printf 'guide'
       ;;
     practices/*.md | practices/*/*.md)

--- a/tools/validate-repository-structure.sh
+++ b/tools/validate-repository-structure.sh
@@ -26,6 +26,11 @@ reject_file() {
   [[ ! -e "$path" ]] || fail "forbidden legacy file present: $path"
 }
 
+reject_path() {
+  local path="$1"
+  [[ ! -e "$path" ]] || fail "forbidden legacy path present: $path"
+}
+
 require_text() {
   local path="$1"
   local text="$2"
@@ -295,6 +300,7 @@ is_active_file() {
     tools/sync-from-hub.sh | \
     tools/test-frontmatter-validator.sh | \
     tools/test-smart-sync.sh | \
+    tools/test-post-migration-validator.sh | \
     tools/validate-frontmatter.sh | \
     tools/validate-file-naming.sh | \
     tools/validate-repository-structure.sh)
@@ -377,7 +383,7 @@ validate_metadata_single_source() {
     ' "$file"; then
       fail "Metadata duplicated in body of $file. Keep it only in frontmatter."
     fi
-  done < <(find standards pr-ops ai-rules ai-governance docs/rfc research -type f -name '*.md' | sort)
+  done < <(find standards pr-ops ai-rules ai-governance projects-sink docs/rfc docs/guides research -type f -name '*.md' | sort)
 }
 
 validate_internal_markdown_links() {
@@ -694,6 +700,7 @@ required_files=(
   "tools/sync-from-hub.sh"
   "tools/test-frontmatter-validator.sh"
   "tools/test-smart-sync.sh"
+  "tools/test-post-migration-validator.sh"
   "tools/validate-frontmatter.sh"
   "tools/validate-file-naming.sh"
   "tools/validate-repository-structure.sh"
@@ -708,8 +715,12 @@ for file in "${required_files[@]}"; do
 done
 
 reject_file "standards/research-profile.md"
+reject_path "governance"
+reject_path "website"
+reject_path "experiments"
+reject_path "mkdocs.yml"
 
-for kebab_case_dir in standards pr-ops ai-rules docs/rfc; do
+for kebab_case_dir in standards pr-ops ai-rules ai-governance docs/rfc docs/guides; do
   validate_kebab_case_file_naming "$kebab_case_dir"
 done
 
@@ -1409,7 +1420,7 @@ require_text "ai-rules/agent-onboarding-protocol.md" "templates/htom/README.md"
 require_text "ai-rules/agent-onboarding-protocol.md" "standards/session-handover-standard.md"
 
 require_text "pr-ops/artifact-map.md" "status: canonical"
-require_text "pr-ops/artifact-map.md" "version: 1.69"
+require_text "pr-ops/artifact-map.md" "version: 1.70"
 require_text "pr-ops/artifact-map.md" "templates/htom/AI_GOVERNANCE.md"
 require_text "pr-ops/artifact-map.md" "templates/spoke/README.md"
 require_text "pr-ops/artifact-map.md" "docs/rfc/htom-vs-spoke-clarification-2026-06.md"
@@ -1479,6 +1490,7 @@ require_text "pr-ops/artifact-map.md" "templates/htom/.github/ISSUE_TEMPLATE/tas
 require_text "pr-ops/artifact-map.md" "templates/spoke/docs/README.md"
 require_text "pr-ops/artifact-map.md" "templates/spoke/tools/validate-file-naming.sh"
 require_text "pr-ops/artifact-map.md" "templates/sync-project-with-hub-prompt.md"
+require_text "pr-ops/artifact-map.md" "tools/test-post-migration-validator.sh"
 require_text "pr-ops/artifact-map.md" "tools/validate-file-naming.sh"
 require_text "pr-ops/artifact-map.md" ".github/workflows/validate.yml"
 require_text "pr-ops/artifact-map.md" "Уровни документации: Framework vs Methodology"
@@ -1713,7 +1725,7 @@ require_text "pr-ops/session-digests.md" "pr-ops/backlog.md"
 reject_text "pr-ops/session-digests.md" "Конард"
 
 require_text "pr-ops/backlog.md" "status: canonical"
-require_text "pr-ops/backlog.md" "version: 1.26"
+require_text "pr-ops/backlog.md" "version: 1.27"
 require_text "pr-ops/backlog.md" "type: backlog"
 require_text "pr-ops/backlog.md" "standards/glossary.md"
 require_text "pr-ops/backlog.md" "## Открытые вопросы"
@@ -1728,6 +1740,8 @@ require_text "pr-ops/backlog.md" "analysis-standard.md"
 require_text "pr-ops/backlog.md" "audit-standard.md"
 require_text "pr-ops/backlog.md" "https://github.com/G-Ivan-A/hybrid-Intelligence-lab/issues/296"
 require_text "pr-ops/backlog.md" "B-034"
+require_text "pr-ops/backlog.md" "B-063"
+require_text "pr-ops/backlog.md" "issue #390"
 require_text "pr-ops/backlog.md" "План миграции репо Хаба"
 require_text "pr-ops/backlog.md" "B-038"
 require_text "pr-ops/backlog.md" "Reports-артефактов"
@@ -2223,7 +2237,6 @@ require_text "projects/repo-development/docs/mango-ba-prompts-repository-migrati
 require_text "projects/repo-development/docs/mango-ba-prompts-repository-migration-plan-2026-06.md" "GitHub Flow + trunk discipline"
 require_text "projects/repo-development/docs/mango-ba-prompts-repository-migration-plan-2026-06.md" "Scenario A"
 require_text "projects/repo-development/docs/mango-ba-prompts-repository-migration-plan-2026-06.md" "Scenario B"
-require_text "projects/repo-development/docs/mango-ba-prompts-repository-migration-plan-2026-06.md" "governance/BACKLOG.md"
 require_text "projects/repo-development/docs/mango-ba-prompts-repository-migration-plan-2026-06.md" "scripts/validation/"
 require_text "projects/repo-development/docs/mango-ba-prompts-repository-migration-plan-2026-06.md" "prompts/experiments/"
 require_text "projects/repo-development/docs/mango-ba-prompts-repository-migration-plan-2026-06.md" "PR #90"
@@ -2283,11 +2296,11 @@ require_text "templates/htom/AI_GOVERNANCE.md" "Обоснованный обх�
 require_text "templates/htom/AI_QUICK_RULES.md" "{{project_name}}"
 require_text "templates/htom/AI_QUICK_RULES.md" "Не создавай"
 require_text "templates/htom/AI_SESSION_HANDOVER_PROMPT.md" "{{REPO_NAME}}"
-require_text "templates/htom/AI_SESSION_HANDOVER_PROMPT.md" "governance/agent-onboarding-protocol.md"
-require_text "templates/htom/AI_SESSION_HANDOVER_PROMPT.md" "version: 0.7"
+require_text "templates/htom/AI_SESSION_HANDOVER_PROMPT.md" "ai-rules/agent-onboarding-protocol.md"
+require_text "templates/htom/AI_SESSION_HANDOVER_PROMPT.md" "version: 0.8"
 require_text "templates/htom/AI_SESSION_HANDOVER_PROMPT.md" "Периодическая суммаризация сессии"
-require_text "templates/htom/AI_SESSION_HANDOVER_PROMPT.md" "governance/session-digests.md"
-require_text "templates/htom/AI_SESSION_HANDOVER_PROMPT.md" "governance/BACKLOG.md"
+require_text "templates/htom/AI_SESSION_HANDOVER_PROMPT.md" "pr-ops/session-digests.md"
+require_text "templates/htom/AI_SESSION_HANDOVER_PROMPT.md" "pr-ops/backlog.md"
 require_text "templates/htom/AI_SESSION_HANDOVER_PROMPT.md" "executable: true"
 require_text "templates/htom/AI_SESSION_HANDOVER_PROMPT.md" "ЭТО АРТЕФАКТ ДЛЯ КОПИРОВАНИЯ. Скопируйте в новый чат."
 require_text "templates/htom/AI_SESSION_HANDOVER_PROMPT.md" "ИСПОЛНИМЫЙ HANDOVER PROMPT — СКОПИРУЙ И ВЫПОЛНИ"
@@ -2300,7 +2313,7 @@ require_text "templates/htom/AI_SESSION_HANDOVER_PROMPT.md" "standards/session-h
 reject_text "templates/htom/AI_SESSION_HANDOVER_PROMPT.md" "Конард"
 require_text "templates/htom/README.md" "AI_SESSION_HANDOVER_PROMPT.md"
 require_text "templates/htom/README.md" "status: canonical"
-require_text "templates/htom/README.md" "version: 0.4"
+require_text "templates/htom/README.md" "version: 0.5"
 require_text "templates/htom/README.md" "## Template Placeholder Policy"
 require_text "templates/htom/README.md" "Source templates may contain placeholders"
 require_text "templates/htom/README.md" "Generated repositories must not keep unresolved source placeholders"
@@ -2308,7 +2321,7 @@ require_text "templates/htom/README.md" "{{date}}"
 require_text "templates/htom/README.md" "{{project_name}}"
 require_text "templates/htom/README.md" "{{hub_url}}"
 require_text "templates/htom/README.md" "{{REPO_NAME}}"
-require_text "templates/htom/README.md" "governance/agent-onboarding-protocol.md"
+require_text "templates/htom/README.md" "ai-rules/agent-onboarding-protocol.md"
 require_text "templates/htom/README.md" "Как валидировать структуру"
 require_text "templates/htom/README.md" "Design Decisions & Rationale"
 require_text "templates/htom/README.md" "Человек задаёт смысл, AI ускоряет путь — вместе по правилам"
@@ -2363,8 +2376,11 @@ require_text "tools/test-frontmatter-validator.sh" "knowledge vocabulary"
 require_text "tools/test-frontmatter-validator.sh" "valid governance status and owner"
 require_text "tools/test-frontmatter-validator.sh" "valid docs/audit metadata"
 require_text "tools/test-frontmatter-validator.sh" "audit required target"
+require_text "tools/test-frontmatter-validator.sh" "valid docs/guides metadata"
+require_text "tools/test-post-migration-validator.sh" "legacy root paths"
 require_text "tools/generate-manifest.py" "templates/manifest.json"
 require_text "tools/validate-frontmatter.sh" "invalid knowledge status"
+require_text "tools/validate-frontmatter.sh" "docs/guides/*.md"
 require_text "tools/validate-frontmatter.sh" "invalid governance status"
 require_text "tools/validate-frontmatter.sh" "frontmatter field is forbidden: ai-generated"
 require_text "tools/validate-frontmatter.sh" "missing required frontmatter field for ADR artifact: decision-type"
@@ -2375,6 +2391,8 @@ require_text ".github/workflows/validate.yml" "Validate file naming"
 require_text ".github/workflows/validate.yml" "./tools/validate-file-naming.sh"
 require_text ".github/workflows/validate.yml" "Test frontmatter validator"
 require_text ".github/workflows/validate.yml" "bash tools/test-frontmatter-validator.sh"
+require_text ".github/workflows/validate.yml" "Test post-migration validator invariants"
+require_text ".github/workflows/validate.yml" "bash tools/test-post-migration-validator.sh"
 require_text ".github/workflows/update-manifest.yml" "chore: update manifest.json"
 require_text ".github/workflows/update-manifest.yml" "templates/**"
 require_text "tools/sync-from-hub.sh" "--report"


### PR DESCRIPTION
## Summary

Fixes G-Ivan-A/hybrid-Intelligence-lab#390.

- Added `tools/test-post-migration-validator.sh` and a CI step that guards the post-B-048 migration invariants.
- Updated `tools/validate-repository-structure.sh` to reject retired root paths: `governance/`, `website/`, `experiments/`, and `mkdocs.yml`.
- Removed stale validator self-checks for migrated `governance/` paths and synchronized HTOM handover links with `ai-rules/`, `pr-ops/`, and `docs/rfc/`.
- Covered `docs/guides/*.md` as guide-class frontmatter and registered the validator revision in `CHANGELOG.md`, `pr-ops/artifact-map.md`, and `pr-ops/backlog.md` (B-063).

## Reproduction

Before the fix, `bash tools/test-post-migration-validator.sh` failed because `validate-repository-structure.sh` still accepted recreated ADR-007 legacy root paths.

After the fix, the regression test passes and checks both the rejected paths and absence of stale validator assertions.

## Validation

- `bash -n tools/*.sh templates/htom/tools/*.sh templates/spoke/tools/*.sh`
- `bash tools/test-frontmatter-validator.sh`
- `bash tools/test-smart-sync.sh`
- `bash tools/test-post-migration-validator.sh`
- `./tools/validate-frontmatter.sh .`
- `./tools/validate-file-naming.sh`
- `./tools/validate-repository-structure.sh`
- `python3 tools/generate-manifest.py --check`

No UI changes; screenshots are not applicable.
